### PR TITLE
Ensure valid path and allow for file suffixes

### DIFF
--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -5,10 +5,13 @@ import re
 import copy
 import matplotlib.dates as mdates
 
+def agg(results , suffix='*'):
 
-def agg(results):
-    allResults = [pd.read_csv(results+fn, skipinitialspace=True, sep='\t',
-                              index_col=0) for fn in os.listdir(results)]
+    allResults = []
+    for p in Path(results).rglob(suffix):
+        allResults.append(
+            pd.read_csv( p.joinpath() , skipinitialspace=True, sep='\t',index_col=0)
+        )     
     df_demix = pd.concat(allResults, axis=1).T
     df_demix.index = [x.split('/')[-1] for x in df_demix.index]
     return df_demix


### PR DESCRIPTION
Use method to create file path instead of concatenation to ensure valid path string. The current implementation requires a / as last element of the path but does not check for it. Added suffix variable to allow for file name pattern. This will retrieve only files with a given suffix from the provided directory. Passing the suffix through the cli needs to be implemented.