### PR TITLE
add support specify outdir in update command

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -62,14 +62,21 @@ def demix(variants, depths, output, eps, barcodes, meta):
 
 
 @cli.command()
-def update():
+@click.option('--outdir', default='-1', help='Output directory save updated files')
+def update(outdir):
+    locDir = os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir))
+    if outdir != '-1':
+        # User specified directory
+        locDir = outdir
+    else:
+        locDir = os.path.join(locDir, 'data')
     # get data from UShER
     print('Downloading a new global tree')
-    download_tree()
+    download_tree(locDir)
     print('Getting outbreak data')
-    get_curated_lineage_data()
+    get_curated_lineage_data(locDir)
     print("Converting tree info to barcodes")
-    convert_tree()  # returns paths for each lineage
+    convert_tree(locDir)  # returns paths for each lineage
     # Now parse into barcode form
     lineagePath = os.path.join(os.curdir, "lineagePaths.txt")
     print('Building barcodes from global phylogenetic tree')
@@ -77,11 +84,11 @@ def update():
     df = parse_tree_paths(df)
     df_barcodes = convert_to_barcodes(df)
     df_barcodes = reversion_checking(df_barcodes)
-    df_barcodes.to_csv(os.path.join(locDir, 'data/usher_barcodes.csv'))
+    df_barcodes.to_csv(os.path.join(locDir, 'usher_barcodes.csv'))
     # delete files generated along the way that aren't needed anymore
     print('Cleaning up')
     os.remove(lineagePath)
-    os.remove(os.path.join(locDir, "data/public-latest.all.masked.pb.gz"))
+    os.remove(os.path.join(locDir, "public-latest.all.masked.pb.gz"))
 
 
 @cli.command()

--- a/freyja/updates.py
+++ b/freyja/updates.py
@@ -4,21 +4,17 @@ import sys
 import subprocess
 
 
-def download_tree():
+def download_tree(locDir):
     url = "http://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/"\
           "UShER_SARS-CoV-2/public-latest.all.masked.pb.gz"
-    locDir = os.path.abspath(os.path.join(os.path.realpath(__file__),
-                                          os.pardir))
-    treePath = os.path.join(locDir, "data/public-latest.all.masked.pb.gz")
+    treePath = os.path.join(locDir, "public-latest.all.masked.pb.gz")
     urllib.request.urlretrieve(url, treePath)
     return treePath
 
 
-def convert_tree():
-    locDir = os.path.abspath(os.path.join(os.path.realpath(__file__),
-                                          os.pardir))
+def convert_tree(locDir):
     print(locDir)
-    treePath = os.path.join(locDir, "data/public-latest.all.masked.pb.gz")
+    treePath = os.path.join(locDir, "public-latest.all.masked.pb.gz")
     varCmd = f"matUtils extract -i {treePath} -C lineagePaths.txt"
     sys.stdout.flush()  # force python to flush
     completed = subprocess.run(varCmd, shell=True, executable="/bin/bash",
@@ -26,14 +22,12 @@ def convert_tree():
     return completed
 
 
-def get_curated_lineage_data():
-    locDir = os.path.abspath(os.path.join(os.path.realpath(__file__),
-                                          os.pardir))
+def get_curated_lineage_data(locDir):
     url2 = "https://raw.githubusercontent.com/outbreak-info/outbreak.info/"\
            "master/web/src/assets/genomics/curated_lineages.json"
     urllib.request.urlretrieve(url2,
                                os.path.join(locDir,
-                                            "data/curated_lineages.json"))
+                                            "curated_lineages.json"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a `--outdir` parameter to the `freyja update` command (related issue: https://github.com/andersen-lab/Freyja/issues/33). If `--outdir` is given the `curated_lineages.json` and `usher_barcodes.csv` output to the given directory. It requires the value of `--outdir` to exist, if there is interest we can `mkdir` if it doesn't exist.

If `--outdir` is not given, the files are written to the default location.

I've tried my best to keep the syntax similar to your syntax

### `freyja update`

```{bash}
freyja update 2>/dev/null
Downloading a new global tree
Getting outbreak data
Converting tree info to barcodes
/home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/data
Building barcodes from global phylogenetic tree
separating combined splits
checking for mutation pairs
Cleaning up


# MD5SUMS
md5sum /home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/data/curated_lineages.json
cf729eb3595d07d8c2bf653b02669dee  /home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/data/curated_lineages.json

md5sum /home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/data/usher_barcodes.csv
e677aef45f3ad6f89326ef11e711fe7c  /home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/data/usher_barcodes.csv
```

### `freyja update --outdir ./`

```{bash}
freyja update --outdir ./  2>/dev/null
Downloading a new global tree
Getting outbreak data
Converting tree info to barcodes
./
Building barcodes from global phylogenetic tree
separating combined splits
checking for mutation pairs
Cleaning up


# MD5SUMS
md5sum curated_lineages.json
cf729eb3595d07d8c2bf653b02669dee  curated_lineages.json

md5sum usher_barcodes.csv
e677aef45f3ad6f89326ef11e711fe7c  usher_barcodes.csv
```

### Pandas related warnings

Not important, but let me know if you want to pin the Pandas version on Bioconda to prevent the following warnings

```
/home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/convert_paths2barcodes.py:27: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  df_barcodes = df_barcodes.append(cladeSeries)

/home/robert_petit/miniconda3/envs/temp-freyja/lib/python3.10/site-packages/freyja/convert_paths2barcodes.py:41: PerformanceWarning: DataFrame is highly fragmented.  This is usually the result of calling `frame.insert` many times, which has poor performance.  Consider joining all columns at once using pd.concat(axis=1) instead. To get a de-fragmented frame, use `newframe = frame.copy()`
  temp[mt] = df_barcodes[c]
```
