### PR TITLE
Fix: #73 Adding scale by viral load flag

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -227,8 +227,11 @@ def plot(agg_results, lineages, times, interval, output, windowsize, colors):
 @click.argument('intro', type=click.Path(exists=True))
 @click.option('--thresh', default=0.01, help='min lineage abundance included')
 @click.option('--headerColor', default='mediumpurple', help='color of header')
+@click.option('--scale_by_viral_load', is_flag=True,
+              help='scale by viral load')
 @click.option('--output', default='mydashboard.html', help='Output html file')
-def dash(agg_results, metadata, title, intro, thresh, headercolor, output):
+def dash(agg_results, metadata, title, intro, thresh, headercolor,
+         scale_by_viral_load, output):
     agg_df = pd.read_csv(agg_results, skipinitialspace=True, sep='\t',
                          index_col=0)
     meta_df = pd.read_csv(metadata, index_col=0)
@@ -240,7 +243,7 @@ def dash(agg_results, metadata, title, intro, thresh, headercolor, output):
     with open(intro, "r") as f:
         introText = ''.join(f.readlines())
     make_dashboard(agg_df, meta_df, thresh, titleText, introText,
-                   output, headercolor)
+                   output, headercolor, scale_by_viral_load)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Overview
- This PR fixes #73.
- This PR does the following: This PR introduces a new flag `--scale_by_viral_load` for the dashboard that allows users to rescale based on the Viral Loads.

## Proof

### Without `--scale_by_viral_load`
![image](https://user-images.githubusercontent.com/30050862/179862399-b5a18d7b-322a-472b-b177-97efe326f23f.png)


### With `--scale_by_viral_load`
![image](https://user-images.githubusercontent.com/30050862/179862353-0b61b8de-489f-455d-9f8e-6abb6136f6b6.png)
