### PR TITLE
Extract reads with all muts present on the same read

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ The above command will generate the relative growth rates for each Lineage and o
 ### Read analysis tools
 We now provide tools for the analysis of indexed bam files given a set of mutations of interest.
 ```
-freyja extract [query-mutations.csv] [input-bam] --output [directory-of-output-file]
+freyja extract [query-mutations.csv] [input-bam] --output [directory-of-output-file] --same_read
 ```
-The above command will extract reads containing one or more mutations of interest and save them to `[input-bam]_extracted.bam`. In order to exclude reads containing one or more mutations, use the following:
+The above command will extract reads containing one or more mutations of interest and save them to `[input-bam]_extracted.bam`. Additionally, the `--same_read` flag can be included to specify that all query mutations must occur on the same read. In order to exclude reads containing one or more mutations, use the following:
 ```
 freyja filter [query-mutations.csv] [input-bam] [min-site] [max-site] --output [directory-of-output-file]
 ```

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -437,13 +437,12 @@ def relgrowthrate(agg_results, metadata, thresh, scale_by_viral_load, nboots,
 @click.argument('input_bam', type=click.Path(exists=True))
 @click.option('--output', default='extracted.bam',
               help='path to save extracted reads')
+@click.option('--same_read', is_flag=True,
+              help='include to specify that query reads must all occur on the\
+                    same read')
 @click.option('--refname', default='NC_045512.2')
-def extract(query_mutations, input_bam, output, refname):
-    '''
-    Extracts a subset of reads from INPUT_BAM containing at least one
-    mutation specified in QUERY_MUTATIONS.csv.
-    '''
-    _extract(query_mutations, input_bam, output, refname)
+def extract(query_mutations, input_bam, output, refname, same_read):
+    _extract(query_mutations, input_bam, output, refname, same_read)
 
 
 @cli.command()
@@ -455,10 +454,6 @@ def extract(query_mutations, input_bam, output, refname):
               help='path to save filtered reads')
 @click.option('--refname', default='NC_045512.2')
 def filter(query_mutations, input_bam, min_site, max_site, output, refname):
-    '''
-    Filters out reads containing at least one mutation specified in
-    QUERY_MUTATIONS.csv, within the range (min_site, max_site)
-    '''
     _filter(query_mutations, input_bam, min_site, max_site, output, refname)
 
 

--- a/freyja/read_analysis_tools.py
+++ b/freyja/read_analysis_tools.py
@@ -2,7 +2,6 @@ import re
 import pysam
 
 
-
 def extract(query_mutations, input_bam, output, refname, same_read):
     # Load data
     with open(query_mutations) as infile:
@@ -188,7 +187,6 @@ def extract(query_mutations, input_bam, output, refname, same_read):
     query_names = [x.query_name for x in reads_considered]
 
     itr = samfile.fetch(refname, min(all_sites), max(all_sites)+1)
-
     for x in itr:
         if x.query_name not in query_names:
             continue
@@ -200,7 +198,6 @@ def extract(query_mutations, input_bam, output, refname, same_read):
 
     print(f'Output saved to {output}')
 
-    print('final reads:', len(final_reads))
     return final_reads
 
 

--- a/freyja/read_analysis_tools.py
+++ b/freyja/read_analysis_tools.py
@@ -2,7 +2,8 @@ import re
 import pysam
 
 
-def extract(query_mutations, input_bam, output, refname):
+
+def extract(query_mutations, input_bam, output, refname, same_read):
     # Load data
     with open(query_mutations) as infile:
         lines = infile.read().splitlines()
@@ -82,7 +83,7 @@ def extract(query_mutations, input_bam, output, refname):
                     if m[1] == 'I':
                         if (start+i+del_spacing-ins_spacing,
                                 seq[i:i+int(m[0])]) in insertions:
-                            reads_considered.append(x.query_name)
+                            reads_considered.append(x)
                             insert_found = True
                             break
                         i += int(m[0])
@@ -106,26 +107,90 @@ def extract(query_mutations, input_bam, output, refname):
                         i += int(m[0])
                     elif m[1] == 'D':
                         if (i, int(m[0])) in deletions:
-                            reads_considered.append(x.query_name)
+                            reads_considered.append(x)
                             continue
                         i += int(m[0])
             else:
                 c_dict = dict(zip(x.get_reference_positions(), seq))
                 for s in sites_in:
                     if snp_dict[s] == c_dict[s]:
-                        reads_considered.append(x.query_name)
+                        reads_considered.append(x)
                         break
     samfile.close()
+
+    # Same process, this time removing reads that don't contain all
+    # query mutations.
+
+    if same_read:
+        temp = reads_considered
+        reads_considered = []
+
+        for x in temp:
+            ref_pos = set(x.get_reference_positions())
+            start = x.reference_start
+            sites_in = list(ref_pos & set(snp_sites))
+            seq = x.query_alignment_sequence
+            cigar = re.findall(r'(\d+)([A-Z]{1})', x.cigarstring)
+
+            for ins in insertions:
+                i = 0
+                del_spacing = 0
+                ins_spacing = 0
+                insert_found = False
+                for m in cigar:
+                    if m[1] == 'I':
+                        if (start+i+del_spacing-ins_spacing,
+                                seq[i:i+int(m[0])]) == ins:
+                            insert_found = True
+                            break
+                        i += int(m[0])
+                        ins_spacing += int(m[0])
+                    elif m[1] == 'D':
+                        del_spacing += int(m[0])
+                    elif m[1] == 'M':
+                        i += int(m[0])
+                if not insert_found:
+                    break
+            if len(insertions) > 0 and not insert_found:
+                continue
+
+            for _del in deletions:
+                deletion_found = False
+                i = x.reference_start
+                for m in cigar:
+                    if m[1] == 'M':
+                        i += int(m[0])
+                    elif m[1] == 'D':
+                        if (i, int(m[0])) == _del:
+                            deletion_found = True
+                            break
+                        i += int(m[0])
+                if not deletion_found:
+                    break
+            if len(deletions) > 0 and not deletion_found:
+                continue
+
+            all_snps_found = True
+            c_dict = dict(zip(x.get_reference_positions(), seq))
+            for s in snp_sites:
+                if s not in sites_in or snp_dict[s] != c_dict[s]:
+                    all_snps_found = False
+                    break
+            if not all_snps_found:
+                continue
+
+            reads_considered.append(x)
 
     # Run again, this time also getting the paired read
     samfile = pysam.AlignmentFile(input_bam, 'rb')
     outfile = pysam.AlignmentFile(output, 'wb', template=samfile)
     final_reads = []
+    query_names = [x.query_name for x in reads_considered]
 
     itr = samfile.fetch(refname, min(all_sites), max(all_sites)+1)
 
     for x in itr:
-        if x.query_name not in reads_considered:
+        if x.query_name not in query_names:
             continue
         outfile.write(x)
         final_reads.append(x.query_name)
@@ -135,6 +200,7 @@ def extract(query_mutations, input_bam, output, refname):
 
     print(f'Output saved to {output}')
 
+    print('final reads:', len(final_reads))
     return final_reads
 
 

--- a/freyja/tests/test_read_analysis.py
+++ b/freyja/tests/test_read_analysis.py
@@ -20,7 +20,8 @@ class ReadAnalysisTests(unittest.TestCase):
         with open(query_file, 'w') as f:
             f.write(snps)
 
-        reads_found = _extract(query_file, input_bam, output, refname)
+        reads_found = _extract(query_file, input_bam, output, refname,
+                               same_read=False)
 
         self.assertFalse('A01535:8:HJ3YYDSX2:4:1235:12427:11052'
                          in reads_found)
@@ -48,7 +49,8 @@ class ReadAnalysisTests(unittest.TestCase):
         with open(query_file, 'w') as f:
             f.write(insertions)
 
-        reads_found = _extract(query_file, input_bam, output, refname)
+        reads_found = _extract(query_file, input_bam, output, refname,
+                               same_read=False)
 
         self.assertTrue('A01535:8:HJ3YYDSX2:4:1158:32669:6809'
                         not in reads_found)
@@ -75,7 +77,8 @@ class ReadAnalysisTests(unittest.TestCase):
         with open(query_file, 'w') as f:
             f.write(deletions)
 
-        reads_found = _extract(query_file, input_bam, output, refname)
+        reads_found = _extract(query_file, input_bam, output, refname,
+                               same_read=False)
 
         self.assertFalse('A01535:8:HJ3YYDSX2:4:1123:4707:5165'
                          in reads_found)


### PR DESCRIPTION
Added `--same_read` flag to extract, which adds an additional screening step in which each candidate read is checked for all query mutations.