### PR TITLE
Replace `color` flag in the Plot module with the `config` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ target/
 profile_default/
 ipython_config.py
 
+# VSCode
+.vscode/
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This resulting aggregated data can analyzed directly as a tsv file, or can be vi
 ```
 freyja plot [aggregated-filename-tsv] --output [plot-filename(.pdf,.png,etc.)]
 ```
-which provides a fractional abundance estimate for all aggregated samples. To modify the provide a lineage specific breakdown, the `--lineages` flag can be used. We now provide a `--colors [path-to-csv-of-hex-codes]` option so users can control the colors of the plot (see `freyja/data/colors.csv` for an [example input file](https://github.com/andersen-lab/Freyja/blob/main/freyja/data/colors.csv).   Example outputs:
+which provides a fractional abundance estimate for all aggregated samples. To modify the provide a lineage specific breakdown, the `--lineages` flag can be used. We now provide a `--config [path-to-plot-config-file]` option that allows users to control the colors and grouping of lineages in the plot. The [plot config file](freyja/data/plot_config.yml) is a yaml file. More information about the plot config file can be found in the [sample config file](freyja/data/plot_config.yml).   Example outputs:
 
 |**Summarized** | **Lineage-Specific**|
 |     :---:      |     :---:      |

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -269,12 +269,12 @@ def aggregate(results, ext, output):
 @click.option('--lineages', is_flag=True)
 @click.option('--times', default='-1')
 @click.option('--interval', default='MS')
-@click.option('--colors', default='', help='path to csv of hex codes')
+@click.option('--config', default=None, help='path to yaml file')
 @click.option('--mincov', default=60., help='min genome coverage included')
 @click.option('--output', default='mix_plot.pdf', help='Output file')
 @click.option('--windowsize', default=14)
 def plot(agg_results, lineages, times, interval, output, windowsize,
-         colors, mincov):
+         config, mincov):
     agg_df = pd.read_csv(agg_results, skipinitialspace=True, sep='\t',
                          index_col=0)
     # drop poor quality samples
@@ -283,16 +283,35 @@ def plot(agg_results, lineages, times, interval, output, windowsize,
     else:
         print('WARNING: Freyja should be updated \
 to include coverage estimates.')
+    if config is not None:
+        with open(config, "r") as f:
+            try:
+                config = yaml.safe_load(f)
+            except yaml.YAMLError as exc:
+                raise ValueError('Error in config file: ' + str(exc))
+
+    with open(os.path.join(locDir, 'data/lineages.yml'), 'r') as f:
+        try:
+            lineages_yml = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            raise ValueError('lineages.yml error, run update: ' + str(exc))
+
+    # converts lineages_yml to a dictionary where the lineage names are the
+    # keys.
+    lineage_info = {}
+    for lineage in lineages_yml:
+        lineage_info[lineage['name']] = {'name': lineage['name'],
+                                         'children': lineage['children']}
+    if config is not None:
+        config = checkConfig(config)
+    else:
+        config = {}
     agg_df['abundances'] = agg_df['abundances'].astype(str)
     agg_df['summarized'] = agg_df['summarized'].astype(str)
     agg_df = agg_df[agg_df['summarized'] != '[]']
-    if len(colors) > 0:
-        colors0 = pd.read_csv(colors, header=None).values[0]
-    else:
-        colors0 = colors
     if times == '-1':
         # make basic plot, without time info
-        makePlot_simple(agg_df, lineages, output, colors0)
+        makePlot_simple(agg_df, lineages, output, config, lineage_info)
     else:
         # make time aware plot
         times_df = pd.read_csv(times, skipinitialspace=True,
@@ -300,7 +319,7 @@ to include coverage estimates.')
         times_df['sample_collection_datetime'] = \
             pd.to_datetime(times_df['sample_collection_datetime'])
         makePlot_time(agg_df, lineages, times_df, interval, output,
-                      windowsize, colors0)
+                      windowsize, config, lineage_info)
 
 
 @cli.command()


### PR DESCRIPTION
## Description

This PR does the following

1. Replaces the `color` flag with the `config` flag. This allows users to group lineages and also assign colors to specific Variants of concern or lineages.
2. Changes the default color for the plot option from `plt.cm.tab20` to [Plotly Dark24](https://plotly.com/python/discrete-color/).
> **Note**  
> If more than 24 lineages are present, then it will throw the following exception: `Too many lineages to show. Use --config to group.`

## Proof of Changes
Used the following files for proof of changes:

- [aggregated_result.tsv](https://github.com/andersen-lab/Freyja/blob/main/freyja/data/aggregated_result.tsv)
- [plot_config.yml](https://github.com/andersen-lab/Freyja/blob/main/freyja/data/plot_config.yml)

### Images

|  | With Lineages | With VOC |
| ------------- | ------------- |  ------------- |
| With time (W-SAT)  |  ![image](https://user-images.githubusercontent.com/30050862/218745998-9a49e61c-5c4c-4d55-9008-2fdda1a3f151.png) | ![image](https://user-images.githubusercontent.com/30050862/218747010-f69984b4-fd4d-45fc-a4ec-e02d4cb8abd2.png)  |
| Without time  | ![image](https://user-images.githubusercontent.com/30050862/218747237-5fefd1a4-c7fe-427b-8165-0d110e486f5f.png)  | ![image](https://user-images.githubusercontent.com/30050862/218747369-10267730-d402-4c72-8cd2-1816b58d5a5d.png)  |

### Commands run to get the above images

1) With time (W-SAT), with lineages
```
freyja plot freyja/data/aggregated_result.tsv --lineages --output plot.pdf --times freyja/data/times_metadata.csv --interval W-SAT --config freyja/data/plot_config.yml
```

2) With time (W-SAT), with VOC
```
freyja plot freyja/data/aggregated_result.tsv --output plot.pdf --times freyja/data/times_metadata.csv --interval W-SAT --config freyja/data/plot_config.yml
```

3) Without time, with lineages
```
freyja plot freyja/data/aggregated_result.tsv --lineages --output plot.pdf --config freyja/data/plot_config.yml
```

4) Without time, with VOC
```
freyja plot freyja/data/aggregated_result.tsv --output plot.pdf --config freyja/data/plot_config.yml
```

