### PR TITLE
tolerance for non-ASCII characters in variants.tsv

### DIFF
--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -41,7 +41,7 @@ def build_mix_and_depth_arrays(fn, depthFn, muts, covcut):
         df = read_snv_frequencies_ivar(fn, depthFn, muts)
 
     # only works for substitutions, but that's what we get from usher tree
-    df_depth = pd.read_csv(depthFn, sep='\t', header=None, index_col=1)
+    df_depth = pd.read_csv(depthFn, sep='\t', header=None, index_col=1, encoding='latin1')
     df['mutName'] = df['REF'] + df['POS'].astype(str) + df['ALT']
     df = df.drop_duplicates(subset='mutName')
     df.set_index('mutName', inplace=True)
@@ -55,7 +55,7 @@ def build_mix_and_depth_arrays(fn, depthFn, muts, covcut):
 
 
 def read_snv_frequencies_ivar(fn, depthFn, muts):
-    df = pd.read_csv(fn, sep='\t')
+    df = pd.read_csv(fn, sep='\t', encoding='latin1')
     return df
 
 
@@ -70,7 +70,8 @@ def read_snv_frequencies_vcf(fn, depthFn, muts):
 
     df = pd.read_csv(fn, comment='#', delim_whitespace=True,
                      header=None,
-                     names=vcfnames)
+                     names=vcfnames,
+                     encoding='latin1')
     vcf_info = df['INFO'].str.split(';', expand=True)
     for j in range(vcf_info.shape[1]):
         if vcf_info[j].str.split('=')[0] is not None:
@@ -289,7 +290,7 @@ def perform_bootstrap(df_barcodes, mix, depths_,
 if __name__ == '__main__':
     print('loading lineage models')
     # read in  barcodes.
-    df_barcodes = pd.read_csv('freyja/data/usher_barcodes.csv', index_col=0)
+    df_barcodes = pd.read_csv('freyja/data/usher_barcodes.csv', index_col=0, encoding='latin1')
     muts = list(df_barcodes.columns)
     mapDict = buildLineageMap()
 


### PR DESCRIPTION
We're seeing non-ASCII characters in the variants TSV file created by

```
> echo Pileup generation for Freyja...
> freyja variants resorted.bam --variants freyja.variants.tsv --depths freyja.depths.tsv --ref $params.referenceSequence
```

This leads to an error:

```
> echo Demixing variants by Freyja and bootstrapping
> freyja demix freyja.variants.tsv freyja.depths.tsv --output freyja.demix --confirmedonly
# error
Traceback (most recent call last):
  File "/hpc/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/bin/freyja", line 10, in <module>
building mix/depth matrices
    sys.exit(cli())
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/freyja/_cli.py", line 256, in boot
    mix, depths_, cov = build_mix_and_depth_arrays(variants, depths, muts,
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/freyja/sample_deconv.py", line 41, in build_mix_and_depth_arrays
    df = read_snv_frequencies_ivar(fn, depthFn, muts)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/freyja/sample_deconv.py", line 58, in read_snv_frequencies_ivar
    df = pd.read_csv(fn, sep='\t')
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 912, in read_csv
    return _read(filepath_or_buffer, kwds)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 583, in _read
    return parser.read(nrows)
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/pandas/io/parsers/readers.py", line 1704, in read
    ) = self._engine.read(  # type: ignore[attr-defined]
  File "/flash/storage/scratch/data-transfer/Jasmine.Amirzadegan/Justin/c-wap/conda/env-freyja/lib/python3.10/site-packages/pandas/io/parsers/c_parser_wrapper.py", line 234, in read
    chunks = self._reader.read_low_memory(nrows)
  File "pandas/_libs/parsers.pyx", line 812, in pandas._libs.parsers.TextReader.read_low_memory
  File "pandas/_libs/parsers.pyx", line 873, in pandas._libs.parsers.TextReader._read_rows
  File "pandas/_libs/parsers.pyx", line 848, in pandas._libs.parsers.TextReader._tokenize_rows
  File "pandas/_libs/parsers.pyx", line 859, in pandas._libs.parsers.TextReader._check_tokenize_status
  File "pandas/_libs/parsers.pyx", line 2017, in pandas._libs.parsers.raise_parser_error
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9f in position 64852: invalid start byte
```

Here's an example of one of the lines in the variants.tsv file that causes the error:

```
NC_045512.2     29921   ▒       G       0       0       0       1       1       93      0.5     2       0.5     FALSE   NA      NA      NA      NA      NA      NA
```

This seems to be coming from [get_base in iVar](https://github.com/andersen-lab/ivar/blob/98c2394639141a21c276f6c2e840c65fa1f6960c/src/ref_seq.cpp) but I can't really be sure beyond that. In any case, the bug can be kind of "papered over" by allowing Pandas to read these files with a more permissive encoding:

```
df = pd.read_csv(fn, sep='\t', encoding='latin1')
```

This PR provides that fix in `sample_deconv.py`.