### PR TITLE
update buildLineageMap to fix issues caused by changes to metadata

### DIFF
--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -10,26 +10,40 @@ from joblib import Parallel, delayed
 from tqdm import tqdm
 import matplotlib
 
-
 def buildLineageMap(locDir):
     # Parsing curated lineage data from outbreak.info
-    if locDir == '-1':
-        locDir = os.path.abspath(os.path.join(os.path.realpath(__file__),
-                                 os.pardir))
-        f0 = open(os.path.join(locDir, 'data/curated_lineages.json'))
-        dat = json.load(f0)
-        f0.close()
-    else:
-        f0 = open(locDir)
-        dat = json.load(f0)
-        f0.close()
-
     mapDict = {}
-    for ind in range(len(dat)):
-        if 'who_name' in dat[ind].keys():
-            for d0 in dat[ind]['pango_descendants']:
-                if dat[ind]['who_name'] is not None:
-                    mapDict[d0] = dat[ind]['who_name']
+    if os.path.isdir(locDir):
+        global_dat = defaultdict(set)
+        for filename in glob.glob(os.path.join(locDir, "*.json")):
+            with open(filename) as f0:
+                dat = json.load(f0)
+                for record in dat:
+                    if 'who_name' in record.keys():
+                        if record['who_name'] is not None:
+                            global_dat[record['who_name']].update(record.get('pango_descendants', []))
+
+        sorted_dat = sorted(global_dat.items(), key=lambda x: len(x[1]), reverse=False)
+
+        for clade, descendants in sorted_dat:
+            for descendant in descendants:
+                if descendant not in mapDict:
+                    mapDict[descendant] = clade 
+    else:
+        if locDir == '-1':
+            locDir = os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir))
+            with open(os.path.join(locDir, 'data/curated_lineages.json')) as f0:
+                dat = json.load(f0)
+        else:
+            with open(locDir) as f0:
+                dat = json.load(f0)
+        # Sort records based on the length of 'pango_descendants'
+        dat = sorted(dat, key=lambda x: len(x.get('pango_descendants', [])), reverse=True)
+        for ind in range(len(dat)):
+            if 'who_name' in dat[ind].keys():
+                for d0 in dat[ind]['pango_descendants']:
+                    if dat[ind]['who_name'] is not None:
+                        mapDict[d0] = dat[ind]['who_name']
     return mapDict
 
 

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -21,6 +21,8 @@ def buildLineageMap(locDir):
         for filename in glob.glob(os.path.join(locDir, "*.json")):
             with open(filename, "r") as f0:
                 dat = json.load(f0)
+                dat = sorted(dat, key=lambda x: len(
+                    x.get('pango_descendants', [])), reverse=True)
                 for record in dat:
                     if 'who_name' in record:
                         if record['who_name'] is not None:

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -9,6 +9,9 @@ import matplotlib.pyplot as plt
 from joblib import Parallel, delayed
 from tqdm import tqdm
 import matplotlib
+import glob
+from collections import defaultdict
+
 
 def buildLineageMap(locDir):
     # Parsing curated lineage data from outbreak.info
@@ -16,29 +19,32 @@ def buildLineageMap(locDir):
     if os.path.isdir(locDir):
         global_dat = defaultdict(set)
         for filename in glob.glob(os.path.join(locDir, "*.json")):
-            with open(filename) as f0:
+            with open(filename, "r") as f0:
                 dat = json.load(f0)
                 for record in dat:
-                    if 'who_name' in record.keys():
-                        if record['who_name'] is not None:
-                            global_dat[record['who_name']].update(record.get('pango_descendants', []))
-
-        sorted_dat = sorted(global_dat.items(), key=lambda x: len(x[1]), reverse=False)
-
+                    if 'who_name' in record:
+                        global_dat[record['who_name']].update(
+                            record.get('pango_descendants', []))
+        # Sort global_dat by number of descendants (largest first)
+        sorted_dat = sorted(global_dat.items(),
+                            key=lambda x: len(x[1]),
+                            reverse=True)
         for clade, descendants in sorted_dat:
             for descendant in descendants:
-                if descendant not in mapDict:
-                    mapDict[descendant] = clade 
+                mapDict[descendant] = clade
     else:
         if locDir == '-1':
-            locDir = os.path.abspath(os.path.join(os.path.realpath(__file__), os.pardir))
-            with open(os.path.join(locDir, 'data/curated_lineages.json')) as f0:
+            locDir = os.path.abspath(
+                os.path.join(os.path.realpath(__file__), os.pardir))
+            with open(os.path.join(
+                    locDir, 'data/curated_lineages.json')) as f0:
                 dat = json.load(f0)
         else:
             with open(locDir) as f0:
                 dat = json.load(f0)
         # Sort records based on the length of 'pango_descendants'
-        dat = sorted(dat, key=lambda x: len(x.get('pango_descendants', [])), reverse=True)
+        dat = sorted(dat, key=lambda x: len(
+            x.get('pango_descendants', [])), reverse=True)
         for ind in range(len(dat)):
             if 'who_name' in dat[ind].keys():
                 for d0 in dat[ind]['pango_descendants']:

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -23,8 +23,9 @@ def buildLineageMap(locDir):
                 dat = json.load(f0)
                 for record in dat:
                     if 'who_name' in record:
-                        global_dat[record['who_name']].update(
-                            record.get('pango_descendants', []))
+                        if record['who_name'] is not None:
+                            global_dat[record['who_name']].update(
+                                record.get('pango_descendants', []))
         # Sort global_dat by number of descendants (largest first)
         sorted_dat = sorted(global_dat.items(),
                             key=lambda x: len(x[1]),


### PR DESCRIPTION
This is to fix issue #141, which is caused by changes to the metadata. There were two issues which cause this:

1. The previous buildLineageMap function was vulnerable to the order of clades in the curated_lineages.json file, meaning that if a lineage is defined as a descendant of e.g., Omicron and XBB.1.5, it would be placed into the dictionary as whichever was found latest in the json file. This was fixed by sorting dat before building the mapDict
2. Another issue was caused by the possibility of a sub-clade being 'collapsed' with its parent in newer versions of the curated_lineages file. For example, the newest metadata doesn't contain BQ.1 or BA.2.75. This can cause inconsistency when using Freyja for monitoring over time. This was fixed by allowing the user to pass a directory (e.g., [history_metadata](u[rl](https://github.com/andersen-lab/Freyja-data)). 

In the latter case, all json files are parsed to create a global mapping over all metadata versions, and then the smallest sub-clade designation for a given lineage is what is added to the mapDict. This has the desired characteristics of allowing a lineage label to be 'over-ridden' by a newer (e.g., more recent) sub-clade designation, while also retaining sub-clade labels in the event that they are later collapsed (as happened with several Omicron variants in the newer metadata). 

Seems to give the correct behavior in several tests:
Sample 1: New metadata (not the desired labeling, lost resolution)
summarized      [('Omicron', 0.9958707976470551)]

Sample 1: Old metadata (desired labels)
summarized      [('BQ.1* [Omicron (BQ.1.X)]', 0.7454849410988087), ('BA.5* [Omicron (BA.5.X)]', 0.25038585654824635)]

Sample 1: history_metadata (all jsons parsed)
summarized      [('BQ.1* [Omicron (BQ.1.X)]', 0.7454849410988087), ('BA.5* [Omicron (BA.5.X)]', 0.25038585654824635)]

Sample 2: New metadata
summarized      [('XBB.1.5* [Omicron (XBB.1.5.X)]', 0.7767297874153445), ('XBB* (XBB.X)', 0.22326994164199904)]

Sample 2: Old metadata 
summarized      [('XBB.1.5* [Omicron (XBB.1.5.X)]', 0.7046380184806573), ('Omicron', 0.22326994164199904), ('Other', 0.07209176893468716)]

Sample 2: history_metadata
summarized      [('XBB.1.5* [Omicron (XBB.1.5.X)]', 0.7767297874153445), ('XBB* (XBB.X)', 0.22326994164199904)]

Several benefits seen with these 2 samples using the 'global' approach using the directory option for builtLineageMap: 

- Sample 1 (pre-XBB sample): Using the historical json's we can avoid the issue of lost resolution in the newer metadata while still allowing nice labelling of 'legacy' samples (important for longer term monitoring efforts)
- Sample 2 (XBB sample): Here we have the benefit of newer metadata which includes some lineages which weren't yet defined in the older metadata (thus classified 'Other') while still retaining the higher resolution labeling (e.g., XBB.1.5 vs just XBB.X) where possible. 

