### PR TITLE
Fix KeyError: 'recombinant parents'

### DIFF
--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -871,14 +871,15 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
                          for lin in tup]
 
         # handle cases where multiple lineage classes are being merged
-        # e.g. (A.5, B.12) or (XBB,XBN)
+        # e.g. (A.5, B.12) or (XBB, XBN)
         multiple_lin_classes = len(
-            set([alias[0] for alias in pango_aliases])) > 1 or \
-            len(
-            set([alias.split('.')[0] for alias in pango_aliases 
-                 if alias.startswith('X')])) > 1
+            set([alias[0] for alias in pango_aliases])) > 1 #or \
+            # len(
+            # set([alias.split('.')[0] for alias in pango_aliases
+            #      if alias.startswith('X')])) > 1
             
         if multiple_lin_classes:
+            parent_aliases = []
             if 'XBB' in pango_aliases:
                 pass
             for alias in pango_aliases:
@@ -895,10 +896,12 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
                     parents = [lineage_data[lin]['alias'] for lin in parents]
 
                     for parent in parents:
-                        # if any([alias.startswith(parent) 
-                              # for alias in pango_aliases]) and\
-                        if parent not in pango_aliases:
-                            pango_aliases.append(parent)
+                        if any([alias.startswith(parent) 
+                              for alias in pango_aliases]) and \
+                                parent not in pango_aliases:
+                            parent_aliases.append(parent)
+
+            pango_aliases += parent_aliases
             print_warning = True
 
         # get MRCA

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -869,6 +869,7 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
     for tup in duplicates:
         pango_aliases = [lineage_data[lin]['alias']
                          for lin in tup]
+        alias_dict = {lineage_data[lin]['alias']: lin for lin in tup}
 
         # handle cases where multiple lineage classes are being merged
         # e.g. (A.5, B.12) or (XBB, XBN)
@@ -879,13 +880,11 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
             # for recombinant lineages, find the parent lineages
             parent_aliases = []
             for alias in pango_aliases:
-                if alias.startswith('X'):
-                    tmp = alias
-                    while 'recombinant_parents' not in lineage_data[alias]:
-                        alias = lineage_data[alias]['parent']
+
+                if 'recombinant_parents' in lineage_data[alias_dict[alias]]:
 
                     # replace with its recombinant parents
-                    pango_aliases.remove(tmp)
+                    pango_aliases.remove(alias)
                     parents = lineage_data[alias]['recombinant_parents'] \
                         .replace('*', '').split(',')
                     parents = [lineage_data[lin]['alias'] for lin in parents]
@@ -910,7 +909,7 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
             mrca = 'Unknown'
             print_warning = True
         else:
-            # otherwise get the shortened alias, if available
+            # otherwise, get the shortened alias, if available
             for lineage in lineage_data:
                 if lineage_data[lineage]['alias'] == mrca:
                     mrca = lineage
@@ -920,7 +919,7 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
         if mrca != 'Unknown':
             mrca += '-like'
 
-        # include count for multiple barcode classes with same MRCA
+        # include index for multiple barcode classes with same MRCA
         if mrca not in alias_count:
             alias_count[mrca] = 0
         else:

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -873,31 +873,27 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
         # handle cases where multiple lineage classes are being merged
         # e.g. (A.5, B.12) or (XBB, XBN)
         multiple_lin_classes = len(
-            set([alias[0] for alias in pango_aliases])) > 1 #or \
-            # len(
-            # set([alias.split('.')[0] for alias in pango_aliases
-            #      if alias.startswith('X')])) > 1
-            
+            set([alias[0] for alias in pango_aliases])) > 1
+
         if multiple_lin_classes:
+            # for recombinant lineages, find the parent lineages
             parent_aliases = []
-            if 'XBB' in pango_aliases:
-                pass
             for alias in pango_aliases:
                 if alias.startswith('X'):
                     tmp = alias
-                    # for recombinant lineages, find the parent lineages
                     while 'recombinant_parents' not in lineage_data[alias]:
                         alias = lineage_data[alias]['parent']
-                    
-                    # Replace with its recombinant parents
+
+                    # replace with its recombinant parents
                     pango_aliases.remove(tmp)
                     parents = lineage_data[alias]['recombinant_parents'] \
                         .replace('*', '').split(',')
                     parents = [lineage_data[lin]['alias'] for lin in parents]
 
+                    # only consider parents related to the other lineages
                     for parent in parents:
-                        if any([alias.startswith(parent) 
-                              for alias in pango_aliases]) and \
+                        if any([alias.startswith(parent)
+                                for alias in pango_aliases]) and \
                                 parent not in pango_aliases:
                             parent_aliases.append(parent)
 
@@ -914,6 +910,7 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
             mrca = 'Unknown'
             print_warning = True
         else:
+            # otherwise get the shortened alias, if available
             for lineage in lineage_data:
                 if lineage_data[lineage]['alias'] == mrca:
                     mrca = lineage
@@ -922,8 +919,8 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff, locDir, output):
         # add flag to indicate that this is a merged lineage
         if mrca != 'Unknown':
             mrca += '-like'
-        
-        # include index for multiple barcode classes with same MRCA
+
+        # include count for multiple barcode classes with same MRCA
         if mrca not in alias_count:
             alias_count[mrca] = 0
         else:


### PR DESCRIPTION
As per #161, when merging recombinant and non-recombinant lineages, check for the `'recombinant parents'` key in `lineage_data` as opposed to checking whether the alias starts with 'X'.