### PR TITLE
Adjust data ranges

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -603,14 +603,19 @@ def covariants(input_bam, min_site, max_site, output,
 @click.argument('covariants', type=click.Path(exists=True))
 @click.option('--output', default='covariants_plot.pdf')
 @click.option('--num_clusters', default=10,
-              help='number of clusters to plot (starting with greatest count)')
+              help='number of clusters to plot (sorted by frequency)')
 @click.option('--min_mutations', default=1,
               help='minimum number of mutations in a cluster to be plotted')
 @click.option('--nt_muts', is_flag=True,
-              help=('if included, include nucleotide mutations in x-labels'
-                    ))
-def plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts):
-    _plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts)
+              help='if included, include nucleotide mutations in x-labels')
+@click.option('--vmin', default=-5, help=('minimum value for colorbar'
+                                          ' (log scale)'))
+@click.option('--vmax', default=0, help=('maximum value for colorbar'
+                                         ' (log scale)'))
+def plot_covariants(covariants, output, num_clusters,
+                    min_mutations, nt_muts, vmin, vmax):
+    _plot_covariants(covariants, output, num_clusters,
+                     min_mutations, nt_muts, vmin, vmax)
 
 
 if __name__ == '__main__':

--- a/freyja/read_analysis_tools.py
+++ b/freyja/read_analysis_tools.py
@@ -769,7 +769,8 @@ def filter_covariants_output(cluster, nt_muts, min_mutations):
         return list(dict.fromkeys(cluster_final))
 
 
-def plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts):
+def plot_covariants(covariants, output, num_clusters,
+                    min_mutations, nt_muts, vmin, vmax):
 
     covariants_df = pd.read_csv(covariants, sep='\t', header=0)
 
@@ -848,8 +849,8 @@ def plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts):
                                                      colors=colors)
     ax = sns.heatmap(plot_df, cmap=cmap,
                      cbar_kws={'label': 'log10 Frequency', 'shrink': 0.5},
-                     vmin=-5,
-                     vmax=0,
+                     vmin=vmin,
+                     vmax=vmax,
                      linewidths=1.5, linecolor='white', square=True)
 
     gray = mcolors.LinearSegmentedColormap.from_list(

--- a/freyja/read_analysis_tools.py
+++ b/freyja/read_analysis_tools.py
@@ -873,7 +873,7 @@ def plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts):
     # Add rectangles for non-NaN cells
     for i, row in enumerate(plot_df.values):
         for j, val in enumerate(row):
-            if val <= 0:
+            if val <= 1:
                 width = np.count_nonzero(~np.isnan(row))
                 rect = Rectangle((j, i), width, 1, fill=False,
                                  edgecolor='black', linewidth=4)

--- a/freyja/read_analysis_tools.py
+++ b/freyja/read_analysis_tools.py
@@ -831,7 +831,7 @@ def plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts):
         for col in colnames:
             if sites[col] in range(coverage_range[0], coverage_range[1]):
                 # Placeholder value for refererence bases
-                sample_row[colnames.index(col)] = 0.0
+                sample_row[colnames.index(col)] = 1.0
             for mut in pattern[1]:
                 if col in mut:
                     sample_row[colnames.index(
@@ -842,20 +842,21 @@ def plot_covariants(covariants, output, num_clusters, min_mutations, nt_muts):
 
     # Plot heatmap
     fig, ax = plt.subplots(figsize=(15, 10))
-    max_nonzero = plot_df[plot_df != 0.0].max().max()
+
     colors = ['#FFFFB2', '#FECC5C', '#FD8D3C', '#E31A1C']
     cmap = mcolors.LinearSegmentedColormap.from_list(name='custom',
                                                      colors=colors)
     ax = sns.heatmap(plot_df, cmap=cmap,
                      cbar_kws={'label': 'log10 Frequency', 'shrink': 0.5},
-                     vmax=max_nonzero,
+                     vmin=-5,
+                     vmax=0,
                      linewidths=1.5, linecolor='white', square=True)
 
     gray = mcolors.LinearSegmentedColormap.from_list(
         name='custom', colors=['#BEBEBE', '#BEBEBE'])
-    plot = sns.heatmap(plot_df, cmap=gray, vmin=-1, vmax=1,
+    plot = sns.heatmap(plot_df, cmap=gray, vmin=0, vmax=2,
                        linewidths=1.75, linecolor='white', square=True,
-                       mask=plot_df < 0, cbar=False, ax=ax)
+                       mask=plot_df <= 0, cbar=False, ax=ax)
 
     # Add line between adjacent non-NaN cells
     for i, row in enumerate(plot_df.values):


### PR DESCRIPTION
Automatically setting vmin/vmax can be misleading when comparing clusters with similar log frequencies.

* Adds vmin and vmax parameters to `plot-covariants` (default -5 and 0, respectively)
* Related adjustments