### PR TITLE
Get refname from input bam for extract/filter

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -561,9 +561,8 @@ def extract(query_mutations, input_bam, output, refname, same_read):
 @click.argument('max_site', default=29903)
 @click.option('--output', default='filtered.bam',
               help='path to save filtered reads')
-@click.option('--refname', default='NC_045512.2')
-def filter(query_mutations, input_bam, min_site, max_site, output, refname):
-    _filter(query_mutations, input_bam, min_site, max_site, output, refname)
+def filter(query_mutations, input_bam, min_site, max_site, output):
+    _filter(query_mutations, input_bam, min_site, max_site, output)
 
 
 @cli.command()

--- a/freyja/read_analysis_tools.py
+++ b/freyja/read_analysis_tools.py
@@ -62,7 +62,7 @@ def read_pair_generator(bam, refname, min_site, max_site):
             del read_dict[qname]
 
 
-def extract(query_mutations, input_bam, output, refname, same_read):
+def extract(query_mutations, input_bam, output, same_read):
 
     # Parse SNPs and Indels from query_mutations
     with open(query_mutations) as infile:
@@ -110,6 +110,8 @@ def extract(query_mutations, input_bam, output, refname, same_read):
         print('extract: Missing index file, try running samtools index',
               input_bam)
         return -1
+    refname = samfile.get_reference_name(0)
+
     outfile = pysam.AlignmentFile(output, 'wb', template=samfile)
 
     min_site = min(all_sites) - 150
@@ -230,7 +232,7 @@ def extract(query_mutations, input_bam, output, refname, same_read):
     return reads_considered
 
 
-def filter(query_mutations, input_bam, min_site, max_site, output, refname):
+def filter(query_mutations, input_bam, min_site, max_site, output):
 
     # Load data
     with open(query_mutations) as infile:
@@ -276,7 +278,7 @@ def filter(query_mutations, input_bam, min_site, max_site, output, refname):
               input_bam)
         return -1
     print("filter: Filtering out reads with specified mutations")
-
+    refname = samfile.get_reference_name(0)
     all_sites = snp_sites + indel_sites
     all_sites.sort()
 

--- a/freyja/tests/test_read_analysis.py
+++ b/freyja/tests/test_read_analysis.py
@@ -11,7 +11,6 @@ class ReadAnalysisTests(unittest.TestCase):
         self.input_bam = 'freyja/data/test.bam'
         self.query_file = 'freyja/data/test_query.csv'
         self.output = 'freyja/data/output.bam'
-        self.refname = 'NC_045512.2'
 
         return super().setUp()
 
@@ -30,7 +29,7 @@ class ReadAnalysisTests(unittest.TestCase):
             f.write(snps)
 
         reads_found = _extract(self.query_file, self.input_bam, self.output,
-                               self.refname, same_read=False)
+                               same_read=False)
         reads_found = [x.query_name for x in reads_found]
 
         self.assertFalse('A01535:8:HJ3YYDSX2:4:1235:12427:11052'
@@ -57,7 +56,7 @@ class ReadAnalysisTests(unittest.TestCase):
             f.write(insertions)
 
         reads_found = _extract(self.query_file, self.input_bam, self.output,
-                               self.refname, same_read=False)
+                               same_read=False)
         reads_found = [x.query_name for x in reads_found]
         self.assertTrue('A01535:8:HJ3YYDSX2:4:1158:32669:6809'
                         not in reads_found)
@@ -82,7 +81,7 @@ class ReadAnalysisTests(unittest.TestCase):
             f.write(deletions)
 
         reads_found = _extract(self.query_file, self.input_bam, self.output,
-                               self.refname, same_read=False)
+                               same_read=False)
         reads_found = [x.query_name for x in reads_found]
         self.assertFalse('A01535:8:HJ3YYDSX2:4:1123:4707:5165'
                          in reads_found)
@@ -108,7 +107,7 @@ class ReadAnalysisTests(unittest.TestCase):
             f.write(snps)
 
         reads_found = _filter(self.query_file, self.input_bam,
-                              75, 600, self.output, self.refname)
+                              75, 600, self.output)
         self.assertTrue('A01535:8:HJ3YYDSX2:4:1235:12427:11052'
                         in reads_found)
         for read in reads:
@@ -130,7 +129,7 @@ class ReadAnalysisTests(unittest.TestCase):
             f.write(insertions)
 
         reads_found = _filter(self.query_file, self.input_bam, 730, 12340,
-                              self.output, self.refname)
+                              self.output)
 
         self.assertTrue('A01535:8:HJ3YYDSX2:4:1158:32669:6809'
                         in reads_found)
@@ -152,7 +151,7 @@ class ReadAnalysisTests(unittest.TestCase):
             f.write(deletions)
 
         reads_found = _filter(self.query_file, self.input_bam, 1400, 2100,
-                              self.output, self.refname)
+                              self.output)
 
         self.assertTrue('A01535:8:HJ3YYDSX2:4:1123:4707:5165'
                         in reads_found)


### PR DESCRIPTION
* As with `covariants`, use `pysam.AlignmentFile.get_reference_name()` to pull reference name instead of a user-specified parameter for `extract` and `filter`.
* Resolves #170 