### PR TITLE
Get lineage def

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,8 @@ To ensure reproducibility of results, we provide old (timestamped) barcodes and 
    src/installation
    src/usage/demix
    src/usage/variants
+   src/usage/barcode-build
+   src/usage/get-lineage-def
    src/usage/update
    src/usage/boot
    src/usage/aggregate

--- a/docs/src/usage/barcode-build.rst
+++ b/docs/src/usage/barcode-build.rst
@@ -1,0 +1,5 @@
+.. click:: freyja._cli:barcode_build
+    :prog: freyja barcode-build
+    :nested: full
+    :commands: barcode-build
+

--- a/docs/src/usage/covariants.rst
+++ b/docs/src/usage/covariants.rst
@@ -24,7 +24,7 @@ to ``freyja/data/NC_045512_Hu-1.fasta``. If you are using a different
 build to perfrom alignment, it is important to pass that file in to
 ``--ref-genome`` instead. Optionally, a gff file
 (e.g. ``freyja/data/NC_045512_Hu-1.gff``) may be included via the
-``--gff-file`` option to output amino acid mutations alongside
+``--annot`` option to output amino acid mutations alongside
 nucleotide mutations. Inclusion thresholds for read-mapping quality and
 the number of observed instances of a set of covariants can be set using
 ``--min_quality`` and ``--min_count`` respectively.

--- a/docs/src/usage/get-lineage-def.rst
+++ b/docs/src/usage/get-lineage-def.rst
@@ -20,14 +20,20 @@ This command fetches the lineage-defining mutations for the specified lineage. D
     (cont...)
 
 
-If a gene annotation file (gff3) is provided along with a reference genome (fasta), the mutations will include the respective amino acid changes.
+If a gene annotation file (gff3) is provided along with a reference genome (fasta), the mutations will include the respective amino acid changes for non-synonymous mutations.
 
 .. code-block:: bash
 
-    freyja get-lineage-def B.1.1.7 --annot freyja/data/NC_045512_Hu-1.gff --ref freyja/data/NC_045512_Hu-1.fasta
-    C241T(None)
-    C913T(ORF1ab:S216S)
-    C3037T(ORF1ab:F924F)
-    C3267T(ORF1ab:T1001I)
-    C5388A(ORF1ab:A1708D)
+    freyja get-lineage-def BA.2.12 --annot freyja/data/NC_045512_Hu-1.gff --ref freyja/data/NC_045512_Hu-1.fasta
+    ...
+    C21618T(S:T19I)
+    T22200G(S:V213G)
+    G22578A(S:G339D)
+    C22674T(S:S371F)
+    T22679C(S:S373P)
+    C22686T(S:S375F)
+    A22688G(S:T376A)
+    G22775A(S:D405N)
+    A22786C(S:R408S)
+    G22813T(S:K417N)
     (cont...)

--- a/docs/src/usage/get-lineage-def.rst
+++ b/docs/src/usage/get-lineage-def.rst
@@ -1,0 +1,33 @@
+.. click:: freyja._cli:get_lineage_def
+    :prog: freyja get-lineage-def
+    :nested: full
+    :commands: get_lineage_def
+    
+------------
+
+**Example Usage:**
+
+This command fetches the lineage-defining mutations for the specified lineage. Defaults to stdout if no output file is specified.
+
+.. code-block:: bash
+
+    freyja get-lineage-def B.1.1.7
+    C241T
+    C913T
+    C3037T
+    C3267T
+    C5388A
+    (cont...)
+
+
+If a gene annotation file (gff3) is provided along with a reference genome (fasta), the mutations will include the respective amino acid changes.
+
+.. code-block:: bash
+
+    freyja get-lineage-def B.1.1.7 --annot freyja/data/NC_045512_Hu-1.gff --ref freyja/data/NC_045512_Hu-1.fasta
+    C241T(None)
+    C913T(ORF1ab:S216S)
+    C3037T(ORF1ab:F924F)
+    C3267T(ORF1ab:T1001I)
+    C5388A(ORF1ab:A1708D)
+    (cont...)

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -291,6 +291,54 @@ def barcode_build(pb, outdir, noncl):
 
 
 @cli.command()
+@click.argument('lineage', type=str)
+@click.option('--barcodes', default='data/usher_barcodes.csv',
+              help='Path to custom barcode file', show_default=True)
+@click.option('--annot', default=None,
+              help='Path to annotation file in gff3 format.'
+              'If included, shows amino acid mutations.')
+@click.option('--ref', default=None,
+              help='Reference file in fasta format.'
+              'Required to display amino acid mutations',
+              show_default=True)
+@click.option('--output', default=None,
+              help='Output file to save lineage definition.'
+              'Defaults to stdout.')
+def get_lineage_def(lineage, barcodes, annot, ref, output):
+    """
+    Get the mutations defining a LINEAGE of interest
+    from provided barcodes
+    """
+    from freyja.read_analysis_utils import parse_gff, translate_snps
+
+    if barcodes == 'data/usher_barcodes.csv':
+        barcodes = os.path.join(locDir, barcodes)
+
+    df = pd.read_csv(barcodes, index_col=0)
+    target = df.loc[lineage]
+    target = target[target > 0]
+    target_muts = list(target.index)
+
+    if annot is not None:
+        if ref is None:
+            raise ValueError('Both annot and ref must be provided'
+                             'to show amino acid mutations')
+        else:
+            gene_positions = parse_gff(annot)
+            aa_mut = translate_snps(target_muts, ref, gene_positions)
+            target_muts = [f'{mut}({aa_mut[mut]})' for mut in target_muts]
+
+    target_muts = ' '.join(target_muts)
+
+    if output is not None:
+        with open(output, 'w') as f:
+            f.write(target_muts)
+    else:
+        print(target_muts)
+    return target_muts
+
+
+@cli.command()
 @click.argument('bamfile',
                 type=click.Path(exists=True))
 @click.option('--ref', help='Reference file in fasta format',
@@ -763,7 +811,7 @@ def filter(query_mutations, input_bam, min_site, max_site, output):
               help='path to save co-occurring mutations', show_default=True)
 @click.option('--ref-genome', type=click.Path(),
               default='data/NC_045512_Hu-1.fasta', show_default=True)
-@click.option('--gff-file', type=click.Path(exists=True),
+@click.option('--annot', type=click.Path(exists=True),
               default=None,
               help=('path to gff file corresponding to reference genome. If '
                     'included, outputs amino acid mutations in addition to '
@@ -783,7 +831,7 @@ def filter(query_mutations, input_bam, min_site, max_site, output):
                     '(in descending order). Set to "site" to sort patterns by '
                     'start site (n ascending order).'), show_default=True)
 def covariants(input_bam, min_site, max_site, output,
-               ref_genome, gff_file, min_quality, min_count, spans_region,
+               ref_genome, annot, min_quality, min_count, spans_region,
                sort_by):
     """
     Finds mutations co-occurring on the same read pair
@@ -796,7 +844,7 @@ def covariants(input_bam, min_site, max_site, output,
 
     from freyja.read_analysis_tools import covariants as _covariants
     _covariants(input_bam, min_site, max_site, output,
-                ref_genome, gff_file, min_quality, min_count, spans_region,
+                ref_genome, annot, min_quality, min_count, spans_region,
                 sort_by)
 
 
@@ -825,23 +873,6 @@ def plot_covariants(covariants, output, num_clusters,
     _plot_covariants(covariants, output, num_clusters,
                      min_mutations, nt_muts, vmin, vmax)
 
-
-@cli.command()
-@click.argument('lineage', type=str)
-@click.option('--barcodes', default='data/usher_barcodes.csv',
-              help='Path to custom barcode file', show_default=True)
-def get_lineage_def(lineage_of_interest, barcodes):
-    """Get the mutations defining a LINEAGE of interest from the usher tree"""
-    if barcodes == 'data/usher_barcodes.csv':
-        barcodes = os.path.join(locDir, barcodes)
-
-    df = pd.read_csv(barcodes,index_col=0)
-    target = df.loc[lineage_of_interest]
-    target = target[target>0]
-    targetMuts = list(target.index)
-    # Write muts to stdout
-    
-    print(' '.join(targetMuts))
 
 if __name__ == '__main__':
     cli()

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -826,5 +826,22 @@ def plot_covariants(covariants, output, num_clusters,
                      min_mutations, nt_muts, vmin, vmax)
 
 
+@cli.command()
+@click.argument('lineage', type=str)
+@click.option('--barcodes', default='data/usher_barcodes.csv',
+              help='Path to custom barcode file', show_default=True)
+def get_lineage_def(lineage_of_interest, barcodes):
+    """Get the mutations defining a LINEAGE of interest from the usher tree"""
+    if barcodes == 'data/usher_barcodes.csv':
+        barcodes = os.path.join(locDir, barcodes)
+
+    df = pd.read_csv(barcodes,index_col=0)
+    target = df.loc[lineage_of_interest]
+    target = target[target>0]
+    targetMuts = list(target.index)
+    # Write muts to stdout
+    
+    print(' '.join(targetMuts))
+
 if __name__ == '__main__':
     cli()

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -329,7 +329,8 @@ def get_lineage_def(lineage, barcodes, annot, ref, output):
         else:
             gene_positions = parse_gff(annot)
             aa_mut = translate_snps(target_muts, ref, gene_positions)
-            target_muts = [f'{mut}({aa_mut[mut]})' for mut in target_muts]
+            target_muts = [f'{mut}({aa_mut[mut]})' if aa_mut[mut] is not None
+                           else f'{mut}' for mut in target_muts]
 
     target_muts = sorted(target_muts, key=lambda x: int(x.split('(')[0][1:-1]))
     target_muts = '\n'.join(target_muts)

--- a/freyja/read_analysis_utils.py
+++ b/freyja/read_analysis_utils.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pysam
 from Bio.Seq import MutableSeq
 from Bio import SeqIO
 
@@ -101,7 +100,7 @@ def parse_gff(gff_file):
 
 
 def translate_snps(snps, ref, gene_positions):
-    
+
     # Load reference genome
     ref = MutableSeq(next(SeqIO.parse(ref, 'fasta')).seq)
 

--- a/freyja/read_analysis_utils.py
+++ b/freyja/read_analysis_utils.py
@@ -134,6 +134,9 @@ def translate_snps(snps, ref, gene_positions):
             continue
         alt_aa = alt_codon.translate()
 
+        if ref_aa == alt_aa or '*' in alt_aa:
+            continue # Synonymous/stop codon mutation
+
         aa_mut = f'{gene}:{ref_aa}{aa_locus}{alt_aa}'
         output[snp] = aa_mut
 

--- a/freyja/read_analysis_utils.py
+++ b/freyja/read_analysis_utils.py
@@ -135,7 +135,7 @@ def translate_snps(snps, ref, gene_positions):
         alt_aa = alt_codon.translate()
 
         if ref_aa == alt_aa or '*' in alt_aa:
-            continue # Synonymous/stop codon mutation
+            continue  # Synonymous/stop codon mutation
 
         aa_mut = f'{gene}:{ref_aa}{aa_locus}{alt_aa}'
         output[snp] = aa_mut

--- a/freyja/tests/test_cli.py
+++ b/freyja/tests/test_cli.py
@@ -53,6 +53,15 @@ class CommandLineTests(unittest.TestCase):
                    --output test_dash.html')
         self.assertTrue(file_exists('.', "test_dash.html"))
 
+    def test_get_lineage_def(self):
+        os.system('freyja get-lineage-def B.1.1.7 '
+                  '--annot freyja/data/NC_045512_Hu-1.gff '
+                  '--ref freyja/data/NC_045512_Hu-1.fasta '
+                  '--output lineage_def.txt')
+        self.assertTrue(file_exists('.', "lineage_def.txt"))
+        with open('lineage_def.txt') as f:
+            self.assertEqual(len(f.readlines()), 28)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/freyja/tests/test_read_analysis.py
+++ b/freyja/tests/test_read_analysis.py
@@ -162,7 +162,7 @@ class ReadAnalysisTests(unittest.TestCase):
 
     def test_covariants(self):
         cmd = ['freyja', 'covariants', self.input_bam,
-               '21563', '25384', '--gff-file',
+               '21563', '25384', '--annot',
                'freyja/data/NC_045512_Hu-1.gff', '--output',
                'freyja/data/test_covar.tsv']
         err = subprocess.run(cmd)


### PR DESCRIPTION
Adds `get-lineage-def` function, allowing the user to get the lineage-defining mutations for a given lineage.
* `--annot` allows for a gff3 file to be passed in, and with `--ref`, outputs amino acid changes alongside mutations.
* Defaults to stdout, but allows custom output file via `--output` option.
* Add test, update docs.