### PR TITLE
Improve error handling

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -126,14 +126,13 @@ def demix(variants, depths, output, eps, barcodes, meta,
     print('demixing')
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
 
-
     sample_strains, abundances = solve_demixing_problem(df_barcodes,
-                                                            mix,
-                                                            depths_,
-                                                            eps, adapt,
-                                                            a_eps,
-                                                            solver)
-    
+                                                        mix,
+                                                        depths_,
+                                                        eps, adapt,
+                                                        a_eps,
+                                                        solver)
+
     # merge intra-lineage diversity if multiple hits.
     if len(set(sample_strains)) < len(sample_strains):
         localDict = {}

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -140,12 +140,13 @@ def demix(variants, depths, output, eps, barcodes, meta,
                                                           autoadapt)
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
     print('demixing')
-    sample_strains, abundances = solve_demixing_problem(df_barcodes,
-                                                        mix,
-                                                        depths_,
-                                                        eps, adapt,
-                                                        a_eps,
-                                                        solver)
+    sample_strains, abundances, error = solve_demixing_problem(df_barcodes,
+                                                               mix,
+                                                               depths_,
+                                                               eps,
+                                                               adapt,
+                                                               a_eps,
+                                                               solver)
     # merge intra-lineage diversity if multiple hits.
     if len(set(sample_strains)) < len(sample_strains):
         localDict = {}
@@ -165,7 +166,7 @@ def demix(variants, depths, output, eps, barcodes, meta,
 
     # assemble into series and write.
     sols_df = pd.Series(data=(localDict, sample_strains, abundances,
-                              cov),
+                              error, cov),
                         index=['summarized', 'lineages',
                         'abundances', 'resid', 'coverage'],
                         name=mix.name)

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -126,18 +126,14 @@ def demix(variants, depths, output, eps, barcodes, meta,
     print('demixing')
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
 
-    try:
-        sample_strains, abundances, error = solve_demixing_problem(df_barcodes,
-                                                                   mix,
-                                                                   depths_,
-                                                                   eps, adapt,
-                                                                   a_eps,
-                                                                   solver)
-    except Exception as e:
-        print(e)
-        print('Error: Demixing step failed. Returning empty data output')
-        sample_strains, abundances = [], []
-        error = -1
+
+    sample_strains, abundances = solve_demixing_problem(df_barcodes,
+                                                            mix,
+                                                            depths_,
+                                                            eps, adapt,
+                                                            a_eps,
+                                                            solver)
+    
     # merge intra-lineage diversity if multiple hits.
     if len(set(sample_strains)) < len(sample_strains):
         localDict = {}
@@ -157,7 +153,7 @@ def demix(variants, depths, output, eps, barcodes, meta,
 
     # assemble into series and write.
     sols_df = pd.Series(data=(localDict, sample_strains, abundances,
-                              error, cov),
+                              cov),
                         index=['summarized', 'lineages',
                         'abundances', 'resid', 'coverage'],
                         name=mix.name)


### PR DESCRIPTION
Previously handled `cp.error.SolverError` in `sample_deconv.py` by writing error to stdout and returning empty output file, causing a faulty run to still return an exit status of 0. Now raises exception directly, causing message to be written to stderr and returning an exit code 1

Closes #256 