### PR TITLE
Don't assume df_barcodes has empty column

### DIFF
--- a/freyja/convert_paths2barcodes.py
+++ b/freyja/convert_paths2barcodes.py
@@ -29,7 +29,8 @@ def convert_to_barcodes(df):
 
     print('separating combined splits')
     df_barcodes = df_barcodes.T
-    df_barcodes = df_barcodes.drop(columns='')
+    if '' in df_barcodes.columns:
+        df_barcodes = df_barcodes.drop(columns='')
     df_barcodes = df_barcodes.fillna(0)
     temp = pd.DataFrame()
     dropList = []


### PR DESCRIPTION
Fixes #266

Wraps the drop statement in a conditional, so that a KeyError isn't raised if the dataframe doesn't have a column named ''.

Alternatively, the `pandas.DataFrame.drop` function has an `errors` parameter which can be set to `ignore` so that an error isn't raised when attempting to drop a non-existant column, but that seems like it could cause some headaches in the future.