### PR TITLE
Extract value of AF field using regex

### DIFF
--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -114,14 +114,8 @@ def read_snv_frequencies_vcf(fn, depthFn, muts):
                      header=None,
                      names=vcfnames)
     vcf_info = df['INFO'].str.split(';', expand=True)
-    for j in range(vcf_info.shape[1]):
-        if vcf_info[j].str.split('=')[0] is not None:
-            if vcf_info[j].str.split('=')[0][0] == 'AF':
-                df["ALT_FREQ"] = vcf_info[j].str.split('=')\
-                    .str[1]\
-                    .values\
-                    .astype(
-                    float)
+    df["ALT_FREQ"] = df["INFO"].str.extract( f"AF=([0-9]*\.*[0-9]+)" )
+    df["ALT_FREQ"] = pd.to_numeric( df["ALT_FREQ"], downcast="float" )
     return df
 
 

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -113,9 +113,9 @@ def read_snv_frequencies_vcf(fn, depthFn, muts):
     df = pd.read_csv(fn, comment='#', sep=r'\s+',
                      header=None,
                      names=vcfnames)
-    vcf_info = df['INFO'].str.split(';', expand=True)
-    df["ALT_FREQ"] = df["INFO"].str.extract( f"AF=([0-9]*\.*[0-9]+)" )
-    df["ALT_FREQ"] = pd.to_numeric( df["ALT_FREQ"], downcast="float" )
+
+    df["ALT_FREQ"] = df["INFO"].str.extract(r"AF=([0-9]*\.*[0-9]+)")
+    df["ALT_FREQ"] = pd.to_numeric(df["ALT_FREQ"], downcast="float")
     return df
 
 


### PR DESCRIPTION
Fixes #268 

Code no longer assumes every variant in VCF has the same number and order of fields in the INFO column (which as far as I know is not enforced by the VCF spec).

Regex pattern should match every integer/float, probably.