### PR TITLE
ensure df_ab_lin and df_ab_sum are dataframes

### DIFF
--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -595,10 +595,10 @@ def get_abundance(agg_df, meta_df, thresh, scale_by_viral_load, config,
         dat = agg_df.loc[sampLabel, 'linDict']
         if isinstance(dat, list):
             if i == 0:
-                df_ab_lin = pd.Series(
+                df_ab_lin = pd.DataFrame(pd.Series(
                     agg_df.loc[sampLabel, 'linDict'][0],
                     name=meta_df.loc[sampLabel,
-                                     'sample_collection_datetime'])
+                                     'sample_collection_datetime']))
             else:
                 df_ab_lin = pd.concat([
                     df_ab_lin,
@@ -608,10 +608,10 @@ def get_abundance(agg_df, meta_df, thresh, scale_by_viral_load, config,
                 ], axis=1)
         else:
             if i == 0:
-                df_ab_lin = pd.Series(
+                df_ab_lin = pd.DataFrame(pd.Series(
                     agg_df.loc[sampLabel, 'linDict'],
                     name=meta_df.loc[sampLabel,
-                                     'sample_collection_datetime'])
+                                     'sample_collection_datetime']))
             else:
                 df_ab_lin = pd.concat([
                     df_ab_lin,
@@ -641,10 +641,10 @@ def get_abundance(agg_df, meta_df, thresh, scale_by_viral_load, config,
         dat = agg_df.loc[sampLabel, 'summarized']
         if isinstance(dat, list):
             if i == 0:
-                df_ab_sum = pd.Series(
+                df_ab_sum = pd.DataFrame(pd.Series(
                     agg_df.loc[sampLabel, 'summarized'][0],
                     name=meta_df.loc[sampLabel,
-                                     'sample_collection_datetime'])
+                                     'sample_collection_datetime']))
             else:
                 df_ab_sum = pd.concat([
                     df_ab_sum,
@@ -654,10 +654,10 @@ def get_abundance(agg_df, meta_df, thresh, scale_by_viral_load, config,
                 ], axis=1)
         else:
             if i == 0:
-                df_ab_sum = pd.Series(
+                df_ab_sum = pd.DataFrame(pd.Series(
                     agg_df.loc[sampLabel, 'summarized'],
                     name=meta_df.loc[sampLabel,
-                                     'sample_collection_datetime'])
+                                     'sample_collection_datetime']))
             else:
                 df_ab_sum = pd.concat([
                     df_ab_sum,


### PR DESCRIPTION
fixes https://github.com/andersen-lab/Freyja/issues/215

The problem with setting `df_ab_lin` and df_ab_sum` to series is that, if there's only a single iteration of the loop, you end up with a series instead of `df` which is hard to deal with. Probably best to keep uniform with a df.

I'm not an expert on df's and concatting, so I'm not positive you end up with same-shaped df here for one iteration vs. two. But I did test it locally on a failing case, and it started passing with these fixes.

Thanks!