### PR TITLE
Limit demix solver threads and set verbosity

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -80,7 +80,7 @@ def print_barcode_version(ctx, param, value):
               default=False, show_default=True)
 @click.option('--depthcutoff', default=0,
               help='exclude sites with coverage depth below this value and'
-              'group identical barcodes', show_default=True)
+              ' group identical barcodes', show_default=True)
 @click.option('--lineageyml', default='',
               help='lineage hierarchy file in a yaml format')
 @click.option('--adapt', default=0.,
@@ -94,7 +94,7 @@ def print_barcode_version(ctx, param, value):
                    ' for which to compute additional coverage estimates')
 @click.option('--relaxedmrca', is_flag=True, default=False,
               help='for use with depth cutoff,'
-              'clusters are assigned robust mrca to handle outliers',
+              ' clusters are assigned robust mrca to handle outliers',
               show_default=True)
 @click.option('--relaxedthresh', default=0.9,
               help='associated threshold for robust mrca function',
@@ -110,7 +110,7 @@ def print_barcode_version(ctx, param, value):
 @click.option('--pathogen', type=click.Choice(pathogens),
               default='SARS-CoV-2',
               help='Pathogen of interest.' +
-              'Not used if using --barcodes option.',
+              ' Not used if using --barcodes option.',
               show_default=True)
 @click.option('--autoadapt', default=False,
               is_flag=True,

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -102,6 +102,11 @@ def print_barcode_version(ctx, param, value):
 @click.option('--solver', default='CLARABEL',
               help='solver used for estimating lineage prevalence',
               show_default=True)
+@click.option('--max-solver-threads', default=0, type=int,
+              help='maximum number of threads for multithreaded demix'
+              ' solvers (0 to choose automatically)', show_default=True)
+@click.option('--verbose-solver', is_flag=True,
+              help='enable solver verbosity')
 @click.option('--pathogen', type=click.Choice(pathogens),
               default='SARS-CoV-2',
               help='Pathogen of interest.' +
@@ -114,8 +119,8 @@ def print_barcode_version(ctx, param, value):
 def demix(variants, depths, output, eps, barcodes, meta,
           covcut, confirmedonly, depthcutoff, lineageyml,
           adapt, a_eps, region_of_interest,
-          relaxedmrca, relaxedthresh, solver, pathogen,
-          autoadapt):
+          relaxedmrca, relaxedthresh, solver, max_solver_threads,
+          verbose_solver, pathogen, autoadapt):
     """
     Generate relative lineage abundances from VARIANTS and DEPTHS
     """
@@ -171,7 +176,9 @@ def demix(variants, depths, output, eps, barcodes, meta,
                                                                eps,
                                                                adapt,
                                                                a_eps,
-                                                               solver)
+                                                               solver,
+                                                               max_solver_threads,
+                                                               verbose_solver)
     # merge intra-lineage diversity if multiple hits.
     if len(set(sample_strains)) < len(sample_strains):
         localDict = {}

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -170,15 +170,17 @@ def demix(variants, depths, output, eps, barcodes, meta,
                                                           autoadapt)
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
     print('demixing')
-    sample_strains, abundances, error = solve_demixing_problem(df_barcodes,
-                                                               mix,
-                                                               depths_,
-                                                               eps,
-                                                               adapt,
-                                                               a_eps,
-                                                               solver,
-                                                               max_solver_threads,
-                                                               verbose_solver)
+    sample_strains, abundances, error = solve_demixing_problem(
+        df_barcodes,
+        mix,
+        depths_,
+        eps,
+        adapt,
+        a_eps,
+        solver,
+        max_solver_threads,
+        verbose_solver
+    )
     # merge intra-lineage diversity if multiple hits.
     if len(set(sample_strains)) < len(sample_strains):
         localDict = {}

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -200,7 +200,7 @@ def solve_demixing_problem(df_barcodes, mix, depths, eps, adapt,
         prob.solve(verbose=verbose, solver=solver_, **solver_kwargs)
     except cp.error.SolverError:
         raise ValueError('Solver error encountered, most '
-                         'likely due to insufficient sequencing depth.'
+                         'likely due to insufficient sequencing depth. '
                          'Try running with --depthcutoff.')
     sol = x.value
     rnorm0 = cp.norm(A @ x - b, 1).value
@@ -219,7 +219,7 @@ def solve_demixing_problem(df_barcodes, mix, depths, eps, adapt,
             prob.solve(verbose=verbose, solver=solver_, **solver_kwargs)
         except cp.error.SolverError:
             raise ValueError('Solver error encountered, most '
-                             'likely due to insufficient sequencing depth.'
+                             'likely due to insufficient sequencing depth. '
                              'Try running with --depthcutoff.')
         sol = np.zeros(len(sol))
         sol[solNz] = x.value


### PR DESCRIPTION
Addresses #290.

This PR adds options `--max-solver-threads` (integer) and `--verbose-solver` (flag) to `freyja demix`. By default, these preserve the existing behavior. The thread limit is enforced only when the Clarabel solver is selected by specifying the `max_threads` solver-specific option (see "Linear Solver Settings" under [Clarabel Solver Settings](https://clarabel.org/stable/api_settings/)). The implementation is flexible enough to support passing similar options to other solvers in the future, if they support it.

It also fixes some spacing issues in the CLI help text and stdout.