### PR TITLE
Fix: group amplicons by name in the ampliconstat plots

### DIFF
--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1309,6 +1309,18 @@ def check_amplicon_coverage(depth_file, amplicons, min_coverage):
         columns=["chromosome", "start", "end", "amplicon_name",
                  "amplification_status", "mean_depth", "amplicon_length"]
     )
+    if not aggregated_df.empty:
+        aggregated_df = (
+            aggregated_df.groupby('amplicon_name', as_index=False)
+            .agg({
+                'chromosome': 'first',
+                'start': 'first',
+                'end': 'first',
+                'amplification_status': 'first',
+                'mean_depth': 'mean',
+                'amplicon_length': 'sum'
+            })
+        )    
     return unaggregated_df, aggregated_df
 
 

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1334,7 +1334,6 @@ def plot_amplicon_depth(unaggregated_df, output):
             return str(val)
 
     plt.figure(figsize=(12, 6))
-    
     unaggregated_df = unaggregated_df.sort_values("position")
 
     # Compute log2 depth
@@ -1352,7 +1351,8 @@ def plot_amplicon_depth(unaggregated_df, output):
 
     # Create dictionary mapping amplicon_number → formatted "start-end"
     bin_dict = {
-        row.amplicon_number: f"{format_pos(row.amplicon_start)}-{format_pos(row.amplicon_end)}"
+        row.amplicon_number: f"{format_pos(row.amplicon_start)}-\
+            {format_pos(row.amplicon_end)}"
         for row in bin_ranges.itertuples()
     }
 
@@ -1381,7 +1381,6 @@ def plot_amplicon_depth(unaggregated_df, output):
     plt.tight_layout()
     plt.savefig(output, dpi=1000)
     plt.show()
-
 
 
 if __name__ == '__main__':

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1241,7 +1241,7 @@ def process_bed_file(bed_file):
     )
     # Extract number and side (LEFT/RIGHT) using regex
     primer_df[['number', 'side']] =\
-        primer_df['name'].str.extract(r'(.+?)_(LEFT|RIGHT)')
+        primer_df['name'].str.extract(r'_(\d+)_((?:LEFT|RIGHT))_')
     # Drop rows where extraction failed (invalid names)
     primer_df.dropna(subset=['number', 'side'], inplace=True)
     # Separate LEFT and RIGHT primers

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1241,7 +1241,7 @@ def process_bed_file(bed_file):
     )
     # Extract number and side (LEFT/RIGHT) using regex
     primer_df[['number', 'side']] =\
-        primer_df['name'].str.extract(r'_(\d+)_((?:LEFT|RIGHT))_')
+        primer_df['name'].str.extract(r'_(\d+)_((?:LEFT|RIGHT))(?:_|$)')
     # Drop rows where extraction failed (invalid names)
     primer_df.dropna(subset=['number', 'side'], inplace=True)
     # Separate LEFT and RIGHT primers
@@ -1351,8 +1351,8 @@ def plot_amplicon_depth(unaggregated_df, output):
 
     # Create dictionary mapping amplicon_number → formatted "start-end"
     bin_dict = {
-        row.amplicon_number: f"{format_pos(row.amplicon_start)}-\
-            {format_pos(row.amplicon_end)}"
+        row.amplicon_number:
+            f"{format_pos(row.amplicon_start)}-{format_pos(row.amplicon_end)}"
         for row in bin_ranges.itertuples()
     }
 


### PR DESCRIPTION
This update ensures that amplicons are grouped by their number and their respective depth is shown in a boxplot. The plot now shows numbers is a shorter format and the code is more flexible in parsing the amplicon names from the provided primer bed file.