### PR TITLE
Fix:Adding option to pass VCF alternative frequency column name

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -13,7 +13,7 @@ pathogens = ['SARS-CoV-2'] + list(pathogen_config.keys())
 
 
 @click.group(context_settings={'show_default': True})
-@click.version_option('2.0.1')
+@click.version_option('2.0.2')
 def cli():
     pass
 
@@ -350,7 +350,10 @@ def update(outdir, noncl, buildlocal, pathogen):
               default='SARS-CoV-2',
               help='Pathogen of interest',
               show_default=True)
-def barcode_build(pb, outdir, redo, noncl, pathogen):
+@click.option('--format', default='feather',
+              type=click.Choice(['feather', 'csv']),
+              show_default=True)
+def barcode_build(pb, outdir, redo, noncl, pathogen, format):
     """
     Build barcodes from a custom protobuf tree
     """
@@ -401,9 +404,11 @@ def barcode_build(pb, outdir, redo, noncl, pathogen):
         df_barcodes = df_barcodes.loc[df_barcodes.index.isin(lineageNames)]
     else:
         print("Including lineages not yet in cov-lineages.")
-    # df_barcodes.to_csv(os.path.join(locDir, 'usher_barcodes.csv'))
-    df_barcodes.reset_index().to_feather(
-        os.path.join(locDir, 'usher_barcodes.feather'))
+    if format == 'csv':
+        df_barcodes.to_csv(os.path.join(locDir, 'usher_barcodes.csv'))
+    else:
+        df_barcodes.reset_index().to_feather(
+            os.path.join(locDir, 'usher_barcodes.feather'))
     dictMuts = {}
     for lin in df_barcodes.index:
         muts = sorted([df_barcodes.columns[m0]

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -168,6 +168,8 @@ def demix(variants, depths, output, eps, barcodes, meta,
                         'It may need to be developed if ' + \
                         'not already present on freyja-barcodes.'
                     raise e
+        else:
+            validate_lineage_parents(lineageyml)
         df_barcodes = collapse_barcodes(df_barcodes, df_depth, depthcutoff,
                                         lineageyml, locDir, output,
                                         relaxedmrca, relaxedthresh,

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -116,11 +116,14 @@ def print_barcode_version(ctx, param, value):
               is_flag=True,
               help='use error profile to set adapt',
               show_default=True)
+@click.option('--freqcol', default='AF',
+              help='Frequency column name in the vcf file',
+              show_default=True)
 def demix(variants, depths, output, eps, barcodes, meta,
           covcut, confirmedonly, depthcutoff, lineageyml,
           adapt, a_eps, region_of_interest,
           relaxedmrca, relaxedthresh, solver, max_solver_threads,
-          verbose_solver, pathogen, autoadapt):
+          verbose_solver, pathogen, autoadapt, freqcol):
     """
     Generate relative lineage abundances from VARIANTS and DEPTHS
     """
@@ -178,13 +181,15 @@ def demix(variants, depths, output, eps, barcodes, meta,
                                                               depths,
                                                               muts,
                                                               covcut,
-                                                              autoadapt)
+                                                              autoadapt,
+                                                              freqcol)
     else:
         mix, depths_, cov, _ = build_mix_and_depth_arrays(variants,
                                                           depths,
                                                           muts,
                                                           covcut,
-                                                          autoadapt)
+                                                          autoadapt,
+                                                          freqcol)
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
     print('demixing')
     sample_strains, abundances, error = solve_demixing_problem(
@@ -580,10 +585,13 @@ def variants(bamfile, ref, variants, depths, refname, minq, annot, varthresh):
               is_flag=True,
               help='use error profile to set adapt',
               show_default=True)
+@click.option('--freqcol', default='AF',
+              help='Frequency column name in the vcf file',
+              show_default=True)
 def boot(variants, depths, output_base, eps, barcodes, meta,
          nb, nt, boxplot, confirmedonly, lineageyml, depthcutoff,
          rawboots, relaxedmrca, relaxedthresh, bootseed,
-         solver, pathogen, autoadapt):
+         solver, pathogen, autoadapt, freqcol):
     """
     Perform bootstrapping method for freyja using VARIANTS and DEPTHS
     """
@@ -623,7 +631,8 @@ def boot(variants, depths, output_base, eps, barcodes, meta,
                                                           depths,
                                                           muts,
                                                           covcut,
-                                                          autoadapt)
+                                                          autoadapt,
+                                                          freqcol)
     print('demixing')
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
     lin_df, constell_df = perform_bootstrap(df_barcodes, mix, depths_,

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import json
-import sys
 import re
 import cvxpy as cp
 import os
@@ -389,39 +388,3 @@ def perform_bootstrap(df_barcodes, mix, depths_,
         fig.tight_layout()
         fig.savefig(basename+'_summarized.'+boxplot)
     return lin_df, constell_df
-
-
-if __name__ == '__main__':
-    print('loading lineage models')
-    # read in  barcodes.
-    df_barcodes = pd.read_csv('freyja/data/usher_barcodes.csv', index_col=0)
-    muts = list(df_barcodes.columns)
-    mapDict = buildLineageMap()
-
-    # grab wastewater sample data
-
-    variants = sys.argv[1]  # variant file
-    depths = sys.argv[2]  # depth file
-    # assemble data from of (possibly) mixed samples
-    muts = list(df_barcodes.columns)
-    eps = 0.001
-    mapDict = buildLineageMap()
-    print('building mix/depth matrices')
-    # assemble data from of (possibly) mixed samples
-    mix, depths_, cov = build_mix_and_depth_arrays(variants, depths, muts)
-    print('demixing')
-    df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
-    sample_strains, abundances, error = solve_demixing_problem(df_barcodes,
-                                                               mix,
-                                                               depths_, eps)
-    localDict = map_to_constellation(sample_strains, abundances, mapDict)
-    # assemble into series and write.
-    sols_df = pd.Series(data=(localDict, sample_strains, abundances, error),
-                        index=['summarized', 'lineages',
-                               'abundances', 'resid'],
-                        name=mix.name)
-    numBootstraps = 100
-    n_jobs = 10
-    lin_out, constell_out = perform_bootstrap(df_barcodes, mix, depths_,
-                                              numBootstraps, eps,
-                                              n_jobs, mapDict, muts)

--- a/freyja/tests/test_deconv.py
+++ b/freyja/tests/test_deconv.py
@@ -22,10 +22,10 @@ class DeconvTests(unittest.TestCase):
         depthFn = 'freyja/data/mixture.depth'
         covcut = 10
         autoadapt = False
-
+        freqcol = "AF"
         for varFn in varFns:
             mix, depths, cov, adapt = build_mix_and_depth_arrays(
-                varFn, depthFn, muts, covcut, autoadapt)
+                varFn, depthFn, muts, covcut, autoadapt, freqcol)
             self.assertTrue(ptypes.is_float_dtype(mix))
             self.assertTrue(ptypes.is_float_dtype(depths))
             df_barcodes_reindexed, mix, depths = reindex_dfs(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ description = ("Freyja recovers relative lineage abundances from mixed "
 
 setup(
     name="freyja",
-    version="2021.10",
+    version="2025-09",
     packages=find_packages(),
     author="Joshua Levy",
     license='BSD 2-Clause',


### PR DESCRIPTION
This update ensures that freyja demix function work with variant calling file produced by different variant callers and let the user specify the name of the column.