### PR TITLE
Solve zero division error when region of interest is specified in demix

### DIFF
--- a/docs/src/wiki/command_line_workflow.rst
+++ b/docs/src/wiki/command_line_workflow.rst
@@ -70,13 +70,13 @@ in the provided reference genome and includes it in the output.
 If you want to calculate the coverage in a specific genomic region, you can use
 ``--region_of_interest`` and provide the regions in a JSON format as following:
 
-.. code:: R
+.. code::
     {
     "1": {
-        "chromosome": "NC_045512.2",
-        "start": 25,
-        "end": 431
-    }
+    "chromosome": "NC_045512.2",
+    "start": 25,
+    "end": 431
+    , ...}
 
 
 If you want to use your local barcodes set, you’ll need to use the

--- a/docs/src/wiki/command_line_workflow.rst
+++ b/docs/src/wiki/command_line_workflow.rst
@@ -68,15 +68,8 @@ Demixing can be performed using the command
 By default, Freyja demix calculates the coverage across all genomic positions
 in the provided reference genome and includes it in the output.
 If you want to calculate the coverage in a specific genomic region, you can use
-``--region_of_interest`` and provide the regions in a JSON format as following:
-
-.. code::
-    {
-    "1": {
-    "chromosome": "NC_045512.2",
-    "start": 25,
-    "end": 431
-    , ...}
+``--region_of_interest`` and provide the regions in a JSON format following the
+same structure as provided `here <https://github.com/andersen-lab/Freyja/blob/main/freyja/data/roi.json>`_
 
 
 If you want to use your local barcodes set, you’ll need to use the

--- a/docs/src/wiki/command_line_workflow.rst
+++ b/docs/src/wiki/command_line_workflow.rst
@@ -70,13 +70,14 @@ in the provided reference genome and includes it in the output.
 If you want to calculate the coverage in a specific genomic region, you can use
 ``--region_of_interest`` and provide the regions in a JSON format as following:
 
-.. code:: python
-     {
-  "1": {
-    "chromosome": "NC_045512.2",
-    "start": 25,
-    "end": 431
-  }
+.. code:: R
+    {
+    "1": {
+        "chromosome": "NC_045512.2",
+        "start": 25,
+        "end": 431
+    }
+
 
 If you want to use your local barcodes set, you’ll need to use the
 ``--barcodes`` option and specify the path of your local barcodes. Note:

--- a/docs/src/wiki/command_line_workflow.rst
+++ b/docs/src/wiki/command_line_workflow.rst
@@ -64,19 +64,20 @@ Demixing can be performed using the command
 
 ``freyja demix variants_files/test.variants.tsv depth_files/test.depth --output demix_files/test.output --confirmedonly``
 
+
 By default, Freyja demix calculates the coverage across all genomic positions
- in the provided reference genome and includes it in the output.
- If you want to calculate the coverage in a specific genomic region, you can use
- ``--region_of_interest`` and provide the regions in a JSON format as following:
- ``
- {
+in the provided reference genome and includes it in the output.
+If you want to calculate the coverage in a specific genomic region, you can use
+``--region_of_interest`` and provide the regions in a JSON format as following:
+
+.. code:: python
+     {
   "1": {
     "chromosome": "NC_045512.2",
     "start": 25,
     "end": 431
   }
-``
- 
+
 If you want to use your local barcodes set, you’ll need to use the
 ``--barcodes`` option and specify the path of your local barcodes. Note:
 While the output of ``freyja variants`` will not change over time, the

--- a/docs/src/wiki/command_line_workflow.rst
+++ b/docs/src/wiki/command_line_workflow.rst
@@ -64,6 +64,19 @@ Demixing can be performed using the command
 
 ``freyja demix variants_files/test.variants.tsv depth_files/test.depth --output demix_files/test.output --confirmedonly``
 
+By default, Freyja demix calculates the coverage across all genomic positions
+ in the provided reference genome and includes it in the output.
+ If you want to calculate the coverage in a specific genomic region, you can use
+ ``--region_of_interest`` and provide the regions in a JSON format as following:
+ ``
+ {
+  "1": {
+    "chromosome": "NC_045512.2",
+    "start": 25,
+    "end": 431
+  }
+``
+ 
 If you want to use your local barcodes set, you’ll need to use the
 ``--barcodes`` option and specify the path of your local barcodes. Note:
 While the output of ``freyja variants`` will not change over time, the

--- a/docs/src/wiki/freyja-measles.rst
+++ b/docs/src/wiki/freyja-measles.rst
@@ -34,13 +34,13 @@ For instance, we generated reads from two different measles samples using this c
 
 .. code::
 
-    bygul simulate-proportions GCA_031128185.1.fna primer.bed measles-reference.fasta --outdir measles-H1-100/
+    bygul simulate-proportions GCA_031128185.1.fna --primers primer.bed --reference measles-reference.fasta --outdir measles-H1-100/
 
 *Mixed sample read simulation:*
 
 .. code::
     
-    bygul simulate-proportions GCA_031128185.1.fna,GCA_031129565.1.fna primer.bed measles-reference.fasta --outdir measles-H1-20-D9-80/ --proportions 0.2,0.8
+    bygul simulate-proportions GCA_031128185.1.fna,GCA_031129565.1.fna --primers primer.bed --reference measles-reference.fasta --outdir measles-H1-20-D9-80/ --proportions 0.2,0.8
 
 
 4. Align your reads to your reference genome using an aligner of your choice. 

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -278,13 +278,6 @@ def demix(variants, depths, output, eps, barcodes, meta,
                         index=['summarized', 'lineages',
                         'abundances', 'resid', 'coverage'],
                         name=mix.name)
-
-    # Determine coverage in region(s) of interest (if specified)
-    if region_of_interest != '':
-
-        sols_df = handle_region_of_interest(region_of_interest, sols_df,
-                                            df_depth, covcut, mix.name)
-
     # convert lineage/abundance readouts to single line strings
     sols_df['lineages'] = ' '.join(sols_df['lineages'])
     sols_df['abundances'] = ['%.8f' % ab for ab in sols_df['abundances']]

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -226,19 +226,22 @@ def demix(variants, depths, output, eps, barcodes, meta,
     print('building mix/depth matrices')
     # assemble data from (possibly) mixed samples
     if autoadapt:
-        mix, depths_, cov, adapt = build_mix_and_depth_arrays(variants,
-                                                              depths,
-                                                              muts,
-                                                              covcut,
-                                                              autoadapt,
-                                                              freqcol)
+        mix, depths_, cov, adapt = \
+            build_mix_and_depth_arrays(variants,
+                                       depths,
+                                       muts,
+                                       covcut,
+                                       autoadapt,
+                                       freqcol,
+                                       region_of_interest)
     else:
         mix, depths_, cov, _ = build_mix_and_depth_arrays(variants,
                                                           depths,
                                                           muts,
                                                           covcut,
                                                           autoadapt,
-                                                          freqcol)
+                                                          freqcol,
+                                                          region_of_interest)
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
     print('demixing')
     sample_strains, abundances, error = solve_demixing_problem(

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -178,7 +178,6 @@ def demix(variants, depths, output, eps, barcodes, meta,
                                       )
     from freyja.utils import (collapse_barcodes,
                               load_barcodes,
-                              handle_region_of_interest,
                               validate_lineage_parents)
     locDir = os.path.abspath(os.path.join(os.path.realpath(__file__),
                              os.pardir))

--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -639,10 +639,13 @@ def variants(bamfile, ref, variants, depths, refname, minq, annot, varthresh):
 @click.option('--freqcol', default='AF',
               help='Frequency column name in the vcf file',
               show_default=True)
+@click.option('--region_of_interest', default='',
+              help='JSON file containing region(s) of interest'
+                   ' for which to compute additional coverage estimates')
 def boot(variants, depths, output_base, eps, barcodes, meta,
          nb, nt, boxplot, confirmedonly, lineageyml, depthcutoff,
          rawboots, relaxedmrca, relaxedthresh, bootseed,
-         solver, pathogen, autoadapt, freqcol):
+         solver, pathogen, autoadapt, freqcol, region_of_interest):
     """
     Perform bootstrapping method for freyja using VARIANTS and DEPTHS
     """
@@ -683,7 +686,8 @@ def boot(variants, depths, output_base, eps, barcodes, meta,
                                                           muts,
                                                           covcut,
                                                           autoadapt,
-                                                          freqcol)
+                                                          freqcol,
+                                                          region_of_interest)
     print('demixing')
     df_barcodes, mix, depths_ = reindex_dfs(df_barcodes, mix, depths_)
     lin_df, constell_df = perform_bootstrap(df_barcodes, mix, depths_,

--- a/freyja/data/roi.json
+++ b/freyja/data/roi.json
@@ -1,0 +1,497 @@
+{
+  "1": {
+    "chromosome": "NC_045512.2",
+    "start": 25,
+    "end": 431
+  },
+  "10": {
+    "chromosome": "NC_045512.2",
+    "start": 2780,
+    "end": 3210
+  },
+  "11": {
+    "chromosome": "NC_045512.2",
+    "start": 3078,
+    "end": 3492
+  },
+  "12": {
+    "chromosome": "NC_045512.2",
+    "start": 3390,
+    "end": 3794
+  },
+  "13": {
+    "chromosome": "NC_045512.2",
+    "start": 3683,
+    "end": 4093
+  },
+  "14": {
+    "chromosome": "NC_045512.2",
+    "start": 3992,
+    "end": 4409
+  },
+  "15": {
+    "chromosome": "NC_045512.2",
+    "start": 4312,
+    "end": 4710
+  },
+  "16": {
+    "chromosome": "NC_045512.2",
+    "start": 4620,
+    "end": 5017
+  },
+  "17": {
+    "chromosome": "NC_045512.2",
+    "start": 4923,
+    "end": 5331
+  },
+  "18": {
+    "chromosome": "NC_045512.2",
+    "start": 5230,
+    "end": 5643
+  },
+  "19": {
+    "chromosome": "NC_045512.2",
+    "start": 5561,
+    "end": 5957
+  },
+  "2": {
+    "chromosome": "NC_045512.2",
+    "start": 324,
+    "end": 727
+  },
+  "20": {
+    "chromosome": "NC_045512.2",
+    "start": 5867,
+    "end": 6272
+  },
+  "21": {
+    "chromosome": "NC_045512.2",
+    "start": 6184,
+    "end": 6582
+  },
+  "22": {
+    "chromosome": "NC_045512.2",
+    "start": 6478,
+    "end": 6885
+  },
+  "23": {
+    "chromosome": "NC_045512.2",
+    "start": 6747,
+    "end": 7156
+  },
+  "24": {
+    "chromosome": "NC_045512.2",
+    "start": 7057,
+    "end": 7467
+  },
+  "25": {
+    "chromosome": "NC_045512.2",
+    "start": 7381,
+    "end": 7770
+  },
+  "26": {
+    "chromosome": "NC_045512.2",
+    "start": 7672,
+    "end": 8092
+  },
+  "27": {
+    "chromosome": "NC_045512.2",
+    "start": 7997,
+    "end": 8395
+  },
+  "28": {
+    "chromosome": "NC_045512.2",
+    "start": 8304,
+    "end": 8714
+  },
+  "29": {
+    "chromosome": "NC_045512.2",
+    "start": 8596,
+    "end": 9013
+  },
+  "3": {
+    "chromosome": "NC_045512.2",
+    "start": 644,
+    "end": 1044
+  },
+  "30": {
+    "chromosome": "NC_045512.2",
+    "start": 8919,
+    "end": 9329
+  },
+  "31": {
+    "chromosome": "NC_045512.2",
+    "start": 9168,
+    "end": 9564
+  },
+  "32": {
+    "chromosome": "NC_045512.2",
+    "start": 9470,
+    "end": 9866
+  },
+  "33": {
+    "chromosome": "NC_045512.2",
+    "start": 9782,
+    "end": 10176
+  },
+  "34": {
+    "chromosome": "NC_045512.2",
+    "start": 10076,
+    "end": 10491
+  },
+  "35": {
+    "chromosome": "NC_045512.2",
+    "start": 10393,
+    "end": 10810
+  },
+  "36": {
+    "chromosome": "NC_045512.2",
+    "start": 10713,
+    "end": 11116
+  },
+  "37": {
+    "chromosome": "NC_045512.2",
+    "start": 11000,
+    "end": 11414
+  },
+  "38": {
+    "chromosome": "NC_045512.2",
+    "start": 11305,
+    "end": 11720
+  },
+  "39": {
+    "chromosome": "NC_045512.2",
+    "start": 11624,
+    "end": 12033
+  },
+  "4": {
+    "chromosome": "NC_045512.2",
+    "start": 944,
+    "end": 1362
+  },
+  "40": {
+    "chromosome": "NC_045512.2",
+    "start": 11937,
+    "end": 12339
+  },
+  "41": {
+    "chromosome": "NC_045512.2",
+    "start": 12234,
+    "end": 12643
+  },
+  "42": {
+    "chromosome": "NC_045512.2",
+    "start": 12519,
+    "end": 12920
+  },
+  "43": {
+    "chromosome": "NC_045512.2",
+    "start": 12831,
+    "end": 13240
+  },
+  "44": {
+    "chromosome": "NC_045512.2",
+    "start": 13124,
+    "end": 13528
+  },
+  "45": {
+    "chromosome": "NC_045512.2",
+    "start": 13463,
+    "end": 13859
+  },
+  "46": {
+    "chromosome": "NC_045512.2",
+    "start": 13752,
+    "end": 14144
+  },
+  "47": {
+    "chromosome": "NC_045512.2",
+    "start": 14045,
+    "end": 14457
+  },
+  "48": {
+    "chromosome": "NC_045512.2",
+    "start": 14338,
+    "end": 14743
+  },
+  "49": {
+    "chromosome": "NC_045512.2",
+    "start": 14647,
+    "end": 15050
+  },
+  "5": {
+    "chromosome": "NC_045512.2",
+    "start": 1245,
+    "end": 1650
+  },
+  "50": {
+    "chromosome": "NC_045512.2",
+    "start": 14953,
+    "end": 15358
+  },
+  "51": {
+    "chromosome": "NC_045512.2",
+    "start": 15214,
+    "end": 15619
+  },
+  "52": {
+    "chromosome": "NC_045512.2",
+    "start": 15535,
+    "end": 15941
+  },
+  "53": {
+    "chromosome": "NC_045512.2",
+    "start": 15855,
+    "end": 16260
+  },
+  "54": {
+    "chromosome": "NC_045512.2",
+    "start": 16112,
+    "end": 16508
+  },
+  "55": {
+    "chromosome": "NC_045512.2",
+    "start": 16386,
+    "end": 16796
+  },
+  "56": {
+    "chromosome": "NC_045512.2",
+    "start": 16692,
+    "end": 17105
+  },
+  "57": {
+    "chromosome": "NC_045512.2",
+    "start": 16986,
+    "end": 17405
+  },
+  "58": {
+    "chromosome": "NC_045512.2",
+    "start": 17323,
+    "end": 17711
+  },
+  "59": {
+    "chromosome": "NC_045512.2",
+    "start": 17615,
+    "end": 18022
+  },
+  "6": {
+    "chromosome": "NC_045512.2",
+    "start": 1540,
+    "end": 1948
+  },
+  "60": {
+    "chromosome": "NC_045512.2",
+    "start": 17911,
+    "end": 18328
+  },
+  "61": {
+    "chromosome": "NC_045512.2",
+    "start": 18244,
+    "end": 18652
+  },
+  "62": {
+    "chromosome": "NC_045512.2",
+    "start": 18550,
+    "end": 18961
+  },
+  "63": {
+    "chromosome": "NC_045512.2",
+    "start": 18869,
+    "end": 19277
+  },
+  "64": {
+    "chromosome": "NC_045512.2",
+    "start": 19183,
+    "end": 19586
+  },
+  "65": {
+    "chromosome": "NC_045512.2",
+    "start": 19485,
+    "end": 19901
+  },
+  "66": {
+    "chromosome": "NC_045512.2",
+    "start": 19810,
+    "end": 20216
+  },
+  "67": {
+    "chromosome": "NC_045512.2",
+    "start": 20090,
+    "end": 20497
+  },
+  "68": {
+    "chromosome": "NC_045512.2",
+    "start": 20377,
+    "end": 20792
+  },
+  "69": {
+    "chromosome": "NC_045512.2",
+    "start": 20677,
+    "end": 21080
+  },
+  "7": {
+    "chromosome": "NC_045512.2",
+    "start": 1851,
+    "end": 2250
+  },
+  "70": {
+    "chromosome": "NC_045512.2",
+    "start": 20988,
+    "end": 21387
+  },
+  "71": {
+    "chromosome": "NC_045512.2",
+    "start": 21294,
+    "end": 21700
+  },
+  "72": {
+    "chromosome": "NC_045512.2",
+    "start": 21532,
+    "end": 21933
+  },
+  "73": {
+    "chromosome": "NC_045512.2",
+    "start": 21865,
+    "end": 22274
+  },
+  "74": {
+    "chromosome": "NC_045512.2",
+    "start": 22091,
+    "end": 22503
+  },
+  "75": {
+    "chromosome": "NC_045512.2",
+    "start": 22402,
+    "end": 22805
+  },
+  "76": {
+    "chromosome": "NC_045512.2",
+    "start": 22648,
+    "end": 23141
+  },
+  "77": {
+    "chromosome": "NC_045512.2",
+    "start": 22944,
+    "end": 23351
+  },
+  "78": {
+    "chromosome": "NC_045512.2",
+    "start": 23219,
+    "end": 23635
+  },
+  "79": {
+    "chromosome": "NC_045512.2",
+    "start": 23553,
+    "end": 23955
+  },
+  "8": {
+    "chromosome": "NC_045512.2",
+    "start": 2154,
+    "end": 2571
+  },
+  "80": {
+    "chromosome": "NC_045512.2",
+    "start": 23853,
+    "end": 24258
+  },
+  "81": {
+    "chromosome": "NC_045512.2",
+    "start": 24171,
+    "end": 24567
+  },
+  "82": {
+    "chromosome": "NC_045512.2",
+    "start": 24426,
+    "end": 24836
+  },
+  "83": {
+    "chromosome": "NC_045512.2",
+    "start": 24750,
+    "end": 25150
+  },
+  "84": {
+    "chromosome": "NC_045512.2",
+    "start": 25051,
+    "end": 25461
+  },
+  "85": {
+    "chromosome": "NC_045512.2",
+    "start": 25331,
+    "end": 25740
+  },
+  "86": {
+    "chromosome": "NC_045512.2",
+    "start": 25645,
+    "end": 26050
+  },
+  "87": {
+    "chromosome": "NC_045512.2",
+    "start": 25951,
+    "end": 26360
+  },
+  "88": {
+    "chromosome": "NC_045512.2",
+    "start": 26242,
+    "end": 26661
+  },
+  "89": {
+    "chromosome": "NC_045512.2",
+    "start": 26564,
+    "end": 26991
+  },
+  "9": {
+    "chromosome": "NC_045512.2",
+    "start": 2483,
+    "end": 2885
+  },
+  "90": {
+    "chromosome": "NC_045512.2",
+    "start": 26873,
+    "end": 27283
+  },
+  "91": {
+    "chromosome": "NC_045512.2",
+    "start": 27152,
+    "end": 27560
+  },
+  "92": {
+    "chromosome": "NC_045512.2",
+    "start": 27447,
+    "end": 27855
+  },
+  "93": {
+    "chromosome": "NC_045512.2",
+    "start": 27700,
+    "end": 28104
+  },
+  "94": {
+    "chromosome": "NC_045512.2",
+    "start": 27996,
+    "end": 28416
+  },
+  "95": {
+    "chromosome": "NC_045512.2",
+    "start": 28190,
+    "end": 28598
+  },
+  "96": {
+    "chromosome": "NC_045512.2",
+    "start": 28512,
+    "end": 28914
+  },
+  "97": {
+    "chromosome": "NC_045512.2",
+    "start": 28827,
+    "end": 29227
+  },
+  "98": {
+    "chromosome": "NC_045512.2",
+    "start": 29136,
+    "end": 29534
+  },
+  "99": {
+    "chromosome": "NC_045512.2",
+    "start": 29452,
+    "end": 29854
+  }
+}

--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -67,7 +67,9 @@ def get_error_rate(muts, df0, df_depths0):
     return error_rate
 
 
-def build_mix_and_depth_arrays(fn, depthFn, muts, covcut, autoadapt, freq_col):
+def build_mix_and_depth_arrays(fn, depthFn, muts, covcut, autoadapt, freq_col,
+                               region_of_interest):
+    from freyja.utils import handle_region_of_interest
     input_is_vcf = fn.lower().endswith('vcf')
     if input_is_vcf:
         df = read_snv_frequencies_vcf(fn, freq_col, depthFn, muts)
@@ -91,7 +93,13 @@ def build_mix_and_depth_arrays(fn, depthFn, muts, covcut, autoadapt, freq_col):
     mix.name = fn
     depths = pd.Series({kI: df_depth.loc[int(re.findall(r'\d+', kI)[0]), 3]
                         .astype(float) for kI in muts}, name=fn)
-    coverage = 100.*np.sum(df_depth.loc[:, 3] >= covcut)/df_depth.shape[0]
+    # Determine coverage in region(s) of interest (if specified)
+    if region_of_interest != '':
+        coverage = handle_region_of_interest(region_of_interest,
+                                             df_depth,
+                                             covcut)
+    else:
+        coverage = 100.*np.sum(df_depth.loc[:, 3] >= covcut)/df_depth.shape[0]
     return mix, depths, coverage, adapt
 
 

--- a/freyja/tests/test_deconv.py
+++ b/freyja/tests/test_deconv.py
@@ -23,6 +23,7 @@ class DeconvTests(unittest.TestCase):
         covcut = 10
         autoadapt = False
         freqcol = "AF"
+        region_of_interest = 'freyja/data/roi.json'
         for varFn in varFns:
             mix, depths, cov, adapt = build_mix_and_depth_arrays(
                 varFn, depthFn, muts, covcut, autoadapt, freqcol,

--- a/freyja/tests/test_deconv.py
+++ b/freyja/tests/test_deconv.py
@@ -25,7 +25,8 @@ class DeconvTests(unittest.TestCase):
         freqcol = "AF"
         for varFn in varFns:
             mix, depths, cov, adapt = build_mix_and_depth_arrays(
-                varFn, depthFn, muts, covcut, autoadapt, freqcol)
+                varFn, depthFn, muts, covcut, autoadapt, freqcol,
+                region_of_interest)
             self.assertTrue(ptypes.is_float_dtype(mix))
             self.assertTrue(ptypes.is_float_dtype(depths))
             df_barcodes_reindexed, mix, depths = reindex_dfs(

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1262,24 +1262,14 @@ def handle_region_of_interest(region_of_interest,
     roi_df['end'] = roi_df['end'].apply(
         lambda x: x if x < ref_len else ref_len)
     roi_df.index.name = 'name'
-
-    # Get percent coverage in each region
-    roi_cov = pd.Series()
+    covered_bases = 0
+    total_bases = 0
     for _, row in roi_df.iterrows():
-        roi_depths = df_depth.loc[(df_depth.index >= row['start']) &
-                                  (df_depth.index <= row['end'])]
-        roi_cov = pd.concat([roi_cov,
-                             pd.Series(
-                                 (sum(roi_depths.loc[:, 3] > covcut) /
-                                     len(roi_depths)) * 100,
-                                 index=[row.name])
-                             ])
-
-    # Write to output
-    output_df = pd.concat([output_df, roi_cov], axis=0)
-    output_df.name = title
-
-    return output_df
+        roi_depths = df_depth.loc[row['start']:row['end']]
+        covered_bases += (roi_depths.iloc[:, 0] > covcut).sum()
+        total_bases += roi_depths.shape[0]
+    coverage = 100 * covered_bases / total_bases
+    return coverage
 
 
 def validate_primer_bed(df):

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1261,10 +1261,20 @@ def handle_region_of_interest(region_of_interest,
     roi_df['start'] = roi_df['start'].apply(lambda x: x if x > 0 else 1)
     roi_df['end'] = roi_df['end'].apply(
         lambda x: x if x < ref_len else ref_len)
-    roi_df.index.name = 'name'
+    # Sort intervals by start
+    intervals = roi_df[['start', 'end']].sort_values(by='start').values
+    # merging overlapping intervals
+    merged = []
+    for start, end in intervals:
+        if not merged or start > merged[-1][1]:
+            merged.append([start, end])
+        else:
+            merged[-1][1] = max(merged[-1][1], end)
+    merged_df = pd.DataFrame(merged, columns=['start', 'end'])
+    # calculating covergae for roi
     covered_bases = 0
     total_bases = 0
-    for _, row in roi_df.iterrows():
+    for _, row in merged_df.iterrows():
         roi_depths = df_depth.loc[row['start']:row['end']]
         covered_bases += (roi_depths.iloc[:, 0] > covcut).sum()
         total_bases += roi_depths.shape[0]

--- a/freyja/utils.py
+++ b/freyja/utils.py
@@ -1244,9 +1244,9 @@ def collapse_barcodes(df_barcodes, df_depth, depthcutoff,
     return df_barcodes
 
 
-def handle_region_of_interest(region_of_interest, output_df,
-                              df_depth, covcut, title):
-
+def handle_region_of_interest(region_of_interest,
+                              df_depth, covcut):
+    ref_len = len(df_depth)
     roi_df = pd.read_json(region_of_interest, orient='index')
 
     roi_df['start'] = roi_df['start'].astype(int)
@@ -1257,11 +1257,10 @@ def handle_region_of_interest(region_of_interest, output_df,
         lambda x: (x['start'], x['end']) if x['start'] < x['end']
         else (x['end'], x['start']), axis=1))
 
-    # Ensure start > 0 and end < 29903
+    # Ensure start > 0 and end < less than len of genome
     roi_df['start'] = roi_df['start'].apply(lambda x: x if x > 0 else 1)
     roi_df['end'] = roi_df['end'].apply(
-        lambda x: x if x < 29903 else 29903)
-
+        lambda x: x if x < ref_len else ref_len)
     roi_df.index.name = 'name'
 
     # Get percent coverage in each region


### PR DESCRIPTION
This update also ensures we only have one coverage in the demix output- depending on the user preference to use regions of interest for coverage calculations or the whole genome