### PR TITLE
Include pathogen in demix output

### DIFF
--- a/freyja/_cli.py
+++ b/freyja/_cli.py
@@ -282,6 +282,7 @@ def demix(variants, depths, output, eps, barcodes, meta,
     sols_df['lineages'] = ' '.join(sols_df['lineages'])
     sols_df['abundances'] = ['%.8f' % ab for ab in sols_df['abundances']]
     sols_df['abundances'] = ' '.join(sols_df['abundances'])
+    sols_df['pathogen'] = pathogen
     sols_df.to_csv(output, sep='\t')
 
 

--- a/freyja/tests/test_cli.py
+++ b/freyja/tests/test_cli.py
@@ -1,3 +1,4 @@
+import csv
 import unittest
 import os
 
@@ -16,6 +17,20 @@ class CommandLineTests(unittest.TestCase):
         os.system('freyja demix freyja/data/test.tsv freyja/data/test.depth \
                    --output test.demixed.tsv')
         self.assertTrue(file_exists('.', "test.demixed.tsv"))
+
+        with open('test.demixed.tsv') as f:
+            reader = csv.reader(f, delimiter='\t')
+            result = {row[0]: row[1] for row in reader if len(row) >= 2}
+
+        self.assertEqual(result['pathogen'], 'SARS-CoV-2')
+        self.assertGreater(float(result['coverage']), 90.0)
+
+        lineages = result['lineages'].split()
+        self.assertIn('A', lineages)
+        self.assertIn('AY.48', lineages)
+
+        abundances = [float(a) for a in result['abundances'].split()]
+        self.assertAlmostEqual(sum(abundances), 1.0, places=2)
 
     def test_demix_with_vcf(self):
         os.system('freyja demix freyja/data/test.vcf freyja/data/test.depth \


### PR DESCRIPTION
With freyja supporting multiple pathogens, it poses an interesting challenge for use with multiqc. Multiqc ingests the demix outputs: https://github.com/MultiQC/MultiQC/blob/3c956163a70ced059ac60d2af231d96e278bdd96/multiqc/modules/freyja/freyja.py#L30

With multiple pathogens, you may end up with multiple files for the same sample. Today, multiqc can't know which lineages/stats apply to which pathogen. If we just annotate it in the csv output, multiqc would be able to name columns e.g. `Top lineages (SARS-CoV-2)`.

Thanks again for the great tool. I tried to spruce up the test coverage a bit too for demix.