### PR TITLE
Clamp fracDefining to 1.0 in perform_bootstrap to avoid numpy binomial "p > 1" crash

### DIFF
--- a/freyja/sample_deconv.py
+++ b/freyja/sample_deconv.py
@@ -311,7 +311,7 @@ def perform_bootstrap(df_barcodes, mix, depths_,
     totalDepth = depths_.sum()
     fracDepths = depths_/totalDepth
 
-    fracDefining = fracDepths.sum()
+    fracDefining = min(fracDepths.sum(), 1.0)  # clamp float rounding above 1.0 -> numpy binomial p>1 (issue #320)
     fracDepths_adj = fracDepths/fracDefining
 
     seed = bootseed


### PR DESCRIPTION
Hi, and thanks for maintaining Freyja! 🙏

**Context.** We run nf-core/viralrecon on a nightly basis across a few cloud backends, and noticed `freyja boot` occasionally failing on a small fraction of samples (~0.5–4% in our runs). Tracing it led to a floating-point edge case in `perform_bootstrap`; this PR proposes a small fix. More detail in #320.

**What happens.** `fracDefining = fracDepths.sum()` is mathematically the identity `totalDepth / totalDepth = 1.0`, but floating-point accumulation can land one ULP above 1.0 (e.g. `1.0000000000000002`). Because that value is passed as the `p` argument to `rng.binomial(totalDepth, fracDefining, numBootstraps)`, numpy rejects `p > 1`:

```
ValueError: p < 0, p > 1 or p is NaN
```

**The change.** Clamp `fracDefining` to its mathematical maximum of 1.0 before it's used as a probability:

```python
fracDefining = min(fracDepths.sum(), 1.0)
```

When the value is already ≤ 1.0 nothing changes; when it rounds above 1.0, `binomial` now receives `p = 1.0` and returns `totalDepth` (the intended result). `fracDepths_adj = fracDepths / fracDefining` is unaffected (division by 1.0).

**Verification.** `rng.binomial(1684431, 1.0000000000000002, 10)` raises the `ValueError` before the change and returns `[1684431, …]` after; a real SARS-CoV-2 sample that triggered the crash runs `freyja boot` to completion with the patch applied.

I didn't include a unit test since the trigger is a float-rounding artifact of specific (depth vector × barcode set) inputs that's tricky to reproduce portably — but I'd be glad to add one if you can suggest a stable way to force it, and of course happy to adjust the approach however you'd prefer.

Fixes #320.

---
*Note: this PR was prepared with the help of an AI agent (Claude Code), and reviewed before submission.*